### PR TITLE
INJIMOB-1399--Clear partners on boarded as part of run

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DeleteCertificatesAndOnboardingPartners.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DeleteCertificatesAndOnboardingPartners.java
@@ -1,0 +1,37 @@
+package io.mosip.testrig.dslrig.ivv.e2e.methods;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+import io.mosip.testrig.apirig.dbaccess.DBManager;
+import io.mosip.testrig.apirig.utils.ConfigManager;
+import io.mosip.testrig.dslrig.ivv.core.base.StepInterface;
+import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
+import io.mosip.testrig.dslrig.ivv.orchestrator.BaseTestCaseUtil;
+import io.mosip.testrig.dslrig.ivv.orchestrator.TestRunner;
+import io.mosip.testrig.dslrig.ivv.orchestrator.dslConfigManager;
+
+public class DeleteCertificatesAndOnboardingPartners extends BaseTestCaseUtil implements StepInterface {
+	public static Logger logger = Logger.getLogger(CheckRIDStage.class);
+
+	static {
+		if (dslConfigManager.IsDebugEnabled())
+			logger.setLevel(Level.ALL);
+		else
+			logger.setLevel(Level.ERROR);
+	}
+
+	@Override
+	public void run() throws RigInternalError {
+		DBManager.executeDBQueries(dslConfigManager.getKMDbUrl(), dslConfigManager.getKMDbUser(),
+				dslConfigManager.getKMDbPass(), dslConfigManager.getKMDbSchema(),
+				TestRunner.getGlobalResourcePath() + "/" + "config/keyManagerCertDataDeleteQueries.txt");
+		DBManager.executeDBQueries(dslConfigManager.getIdaDbUrl(), dslConfigManager.getIdaDbUser(),
+				dslConfigManager.getPMSDbPass(), dslConfigManager.getIdaDbSchema(),
+				TestRunner.getGlobalResourcePath() + "/" + "config/idaCertDataDeleteQueries.txt");
+		DBManager.executeDBQueries(dslConfigManager.getMASTERDbUrl(), dslConfigManager.getMasterDbUser(),
+				dslConfigManager.getMasterDbPass(), dslConfigManager.getMasterDbSchema(),
+				TestRunner.getGlobalResourcePath() + "/" + "config/masterDataCertDataDeleteQueries.txt");
+	}
+
+}

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/idaCertDataDeleteQueries.txt
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/idaCertDataDeleteQueries.txt
@@ -1,0 +1,8 @@
+#####  DB queries to be executed to tear down the data used and generated during the test rig run
+
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_pid%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_ekyc_pid%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_device_pid%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_ftm_pid%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/keyManagerCertDataDeleteQueries.txt
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/keyManagerCertDataDeleteQueries.txt
@@ -1,0 +1,14 @@
+#####  DB queries to be executed to tear down the data used and generated during the test rig run
+
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_pid%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_ekyc_pid%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_device_pid%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_ftm_pid%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=masterdata_pid%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=masterdata_ekyc_pid%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=masterdata_device_pid%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=masterdata_ftm_pid%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/masterDataCertDataDeleteQueries.txt
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/masterDataCertDataDeleteQueries.txt
@@ -1,0 +1,8 @@
+#####  DB queries to be executed to tear down the data used and generated during the test rig run
+
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_pid%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_ekyc_pid%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_device_pid%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=masterdata_ftm_pid%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -19984,6 +19984,12 @@
 			"Action": "e2e_Center(DCOM,$$details3,3/*CENTER_INDEX*/)"
 		},
 		"Step-17": {
+			"Description": "Decomissions certificates and onboarding the partners",
+			"Input Parameters": "<<<Step inputs values details>>>",
+			"Return Value": "NA",
+			"Action": "e2e_DeleteCertificatesAndOnboardingPartners()"
+		},
+		"Step-18": {
 			"Description": "Write the persona data into a json file",
 			"Input Parameters": "NA",
 			"Return Value": "NA",


### PR DESCRIPTION
For every run in Before suite  we are creating certificates and onboarding the partners.  As part of tear down we remove them.