### PR TITLE
INJIMOB-2577-Add step to setup dsl code in IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Below are repository details of various modules used for the automation
 1. Biometric Devices= Contains Mockmds specific files.
 1. config= application.properties configurations
 1. config=default.properties
+1. dslConfig=dsl.properties
 1. mapper=demographic mappings environment specific or default setup.
 1. privatekeys=machine specific details for encrypting and signing the packet.					
 1.	Update ..\run.bat as mentioned below
@@ -74,6 +75,44 @@ Below are repository details of various modules used for the automation
 ## DSL execution logs
 1. We can verify the failure in the logs `mosip-acceptance-tests\ivv-orchestrator\src\logs\mosip-api-test.log`
 
+## Importing the Project into an IDE
+
+To work with the project in an Integrated Development Environment (IDE), follow these steps:
+
+1.**Supported IDEs:**
+   - IntelliJ IDEA (Recommended)
+   - Eclipse IDE
+
+2.**Prerequisites:**
+   - Ensure **Java 21** and **Maven** are installed and configured in your system.
+   - Git Bash (for cloning the repository and running scripts).
+
+3.**Steps to Import the Project:**
+   - Clone the repository using the command:
+     ```
+     git clone https://github.com/mosip/mosip-automation-tests.git
+     ```
+   - Open the IDE of your choice.
+   - Select **File > Open Project** (or **File > Import** in Eclipse).
+   - Navigate to the directory where the repository is cloned.
+   - Select the `pom.xml` file and import the project as a **Maven Project**.
+
+4.**Dependencies:**
+   - The project uses Maven for dependency management. Ensure all dependencies are downloaded by running:
+     ```
+     mvn clean install -Dgpg.skip
+     ```
+     This step will also verify that the project builds successfully.
+
+5.**Environment-Specific Configurations:**
+   - Update the `Kernel.properties` file and other configuration files under the `src/main/resources/config` directory as per your environment setup.
+
+6.**Run the Project:**
+   - After importing, locate the main class to run the project:
+     - For DSL Orchestrator: `io.mosip.testrig.dslrig.ivv.orchestrator.TestRunner`.
+   - Use the IDE’s **Run** feature or execute the JAR file with VM arguments for testing.
+
+By following these steps, you can seamlessly set up and work with the project in your preferred IDE.
 
 ## Docker setup build
 1. Deploy Packet creator
@@ -96,3 +135,4 @@ Below are repository details of various modules used for the automation
 
 ## License
 This project is licensed under the terms of [Mozilla Public License 2.0](LICENSE).
+

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -20540,6 +20540,368 @@
 		}
 	},
 	{
+		"Scenario": "182",
+		"Tag": "Postive_Test",
+		"Persona": "ResidentFemaleAdult",
+		"Group": "Adult_New",
+		"Description": "Resident walks into reg-center and generates UIN1 same person tried to get UIN2 and UIN3 (based on MV decision) resident tries to update UIN1 with biometrics and uploads packet and updates successfully",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Details can be found in in-line comments on the parameters",
+			"Return Value": "pre-requiste details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Enviornment and user details. Other prarameters details can be found in-line",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false,Female)"
+		},
+		"Step-5": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-6": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid1=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-7": {
+			"Description": "Checkes the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid1)"
+		},
+		"Step-8": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin1=e2e_getUINByRid($$rid1)"
+		},
+		"Step-9": {
+			"Description": "Generates the hash for the given modalities",
+			"Input Parameters": "Modalitie and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "Hash value",
+			"Action": "$$modalityHashValue=e2e_getBioModalityHash(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger@@Left LittleFinger,$$personaFilePath)"
+		},
+		"Step-10": {
+			"Description": "Sets expectatation on mock ABIS",
+			"Input Parameters": "Modalities hash value. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_configureMockAbis(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger,true/*DUPLICATE_FLAG*/,Right IndexFinger,$$personaFilePath,$$modalityHashValue,-1/*DEFAULT_MOCK_DELAY*/,@@Duplicate/*STATUS_CODE*/)"
+		},
+		"Step-11": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath2=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-12": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid2=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath2)"
+		},
+		"Step-13": {
+			"Description": "Sets manual verification status",
+			"Input Parameters": "RID and status",
+			"Return Value": "NA",
+			"Action": "e2e_postMockMv($$rid2,PROCESSED)"
+		},
+		"Step-14": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid2)"
+		},
+		"Step-15": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin2=e2e_getUINByRid($$rid2)"
+		},
+		"Step-16": {
+			"Description": "Generates the hash for the given modalities",
+			"Input Parameters": "Modalitie and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "Hash value",
+			"Action": "$$modalityHashValue=e2e_getBioModalityHash(-1/*CHECK_PERSONA_PRESENCE*/,Left@@Right,$$personaFilePath)"
+		},
+		"Step-17": {
+			"Description": "Sets expectatation on mock ABIS",
+			"Input Parameters": "Modalities hash value. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_configureMockAbis(-1/*CHECK_PERSONA_PRESENCE*/,Left@@Right,true/*DUPLICATE_FLAG*/,Right IndexFinger,$$personaFilePath,$$modalityHashValue,-1/*DEFAULT_MOCK_DELAY*/,@@Duplicate/*STATUS_CODE*/)"
+		},
+		"Step-20": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$updateTemplate3=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-21": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid3=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$updateTemplate3)"
+		},
+		"Step-22": {
+			"Description": "Sets manual verification status",
+			"Input Parameters": "RID and status",
+			"Return Value": "NA",
+			"Action": "e2e_postMockMv($$rid3,PROCESSED)"
+		},
+		"Step-23": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid3)"
+		},
+		"Step-24": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin3=e2e_getUINByRid($$rid3)"
+		},
+		"Step-25": {
+			"Description": "Generates the hash for the given modalities",
+			"Input Parameters": "Modalitie and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "Hash value",
+			"Action": "$$modalityHashValue=e2e_getBioModalityHash(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger@@Left LittleFinger,$$personaFilePath)"
+		},
+		"Step-26": {
+			"Description": "Sets expectatation on mock ABIS",
+			"Input Parameters": "Modalities hash value. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_configureMockAbis(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger,true/*DUPLICATE_FLAG*/,Right IndexFinger,$$personaFilePath,$$modalityHashValue,-1/*DEFAULT_MOCK_DELAY*/,@@Duplicate/*STATUS_CODE*/)"
+		},
+		"Step-27": {
+			"Description": "Updates Demo graphic details and biometric in the persona file",
+			"Input Parameters": "Data to update and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+ 			"Action": "e2e_updateDemoOrBioDetails(0/*BIO_TYPE*/,face@@leftEye@@rightEye@@rightIndex@@rightLittle@@rightRing@@rightMiddle@@leftIndex@@leftLittle@@leftRing@@leftMiddle@@leftThumb@@rightThumb,0,$$personaFilePath)"
+		},
+		"Step-28": {
+			"Description": "Updates persona with UIN",
+			"Input Parameters": "Persona file path and UIN",
+			"Return Value": "NA",
+			"Action": "e2e_updateResidentWithUIN($$personaFilePath,$$uin1)"
+		},
+		"Step-29": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$updateTemplate4=e2e_getPacketTemplate(UPDATE/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-30": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid4=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$updateTemplate4)"
+		},
+		"Step-31": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid4)"
+		},
+		"Step-32": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin4=e2e_getUINByRid($$rid4)"
+		},
+		"Step-33": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$rid4,MANUAL_ADJUDICATION,SUCCESS)"
+		},
+		"Step-34": {
+			"Description": "Checks uin after updating it",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckUpdatedUIN($$uin1,$$uin4)"
+		}
+	},
+	{
+		"Scenario": "183",
+		"Tag": "Postive_Test",
+		"Persona": "ResidentFemaleAdult",
+		"Group": "Adult_New",
+		"Description": "Resident walks into reg-center and generated UIN1 same person tried to get UIN 2 and failed to UIN as per MV decision resident tries to update biometrics with UIN1 and updates successfully",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Details can be found in in-line comments on the parameters",
+			"Return Value": "pre-requiste details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Enviornment and user details. Other prarameters details can be found in-line",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false,Female)"
+		},
+		"Step-5": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-6": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid1=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-7": {
+			"Description": "Checkes the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid1)"
+		},
+		"Step-8": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin1=e2e_getUINByRid($$rid1)"
+		},
+		"Step-9": {
+			"Description": "Generates the hash for the given modalities",
+			"Input Parameters": "Modalitie and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "Hash value",
+			"Action": "$$modalityHashValue=e2e_getBioModalityHash(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger@@Left LittleFinger,$$personaFilePath)"
+		},
+		"Step-10": {
+			"Description": "Sets expectatation on mock ABIS",
+			"Input Parameters": "Modalities hash value. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_configureMockAbis(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger,true/*DUPLICATE_FLAG*/,Right IndexFinger,$$personaFilePath,$$modalityHashValue,-1/*DEFAULT_MOCK_DELAY*/,@@Duplicate/*STATUS_CODE*/)"
+		},
+		"Step-11": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-12": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid2=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-13": {
+			"Description": "Sets manual verification status",
+			"Input Parameters": "RID and status",
+			"Return Value": "NA",
+			"Action": "e2e_postMockMv($$rid2,REJECTED)"
+		},
+		"Step-14": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(REJECTED/*PACKET_STATUS*/,$$rid2)"
+		},
+		"Step-15": {
+			"Description": "Generates the hash for the given modalities",
+			"Input Parameters": "Modalitie and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "Hash value",
+			"Action": "$$modalityHashValue=e2e_getBioModalityHash(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger@@Left LittleFinger,$$personaFilePath)"
+		},
+		"Step-16": {
+			"Description": "Sets expectatation on mock ABIS",
+			"Input Parameters": "Modalities hash value. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_configureMockAbis(-1/*CHECK_PERSONA_PRESENCE*/,Right IndexFinger,true/*DUPLICATE_FLAG*/,Right IndexFinger,$$personaFilePath,$$modalityHashValue,-1/*DEFAULT_MOCK_DELAY*/,@@Duplicate/*STATUS_CODE*/)"
+		},
+		"Step-17": {
+			"Description": "Updates Demo graphic details and biometric in the persona file",
+			"Input Parameters": "Data to update and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+ 			"Action": "e2e_updateDemoOrBioDetails(0/*BIO_TYPE*/,face@@leftEye@@rightEye@@rightIndex@@rightLittle@@rightRing@@rightMiddle@@leftIndex@@leftLittle@@leftRing@@leftMiddle@@leftThumb@@rightThumb,0,$$personaFilePath)"
+		},
+		"Step-18": {
+			"Description": "Updates persona with UIN",
+			"Input Parameters": "Persona file path and UIN",
+			"Return Value": "NA",
+			"Action": "e2e_updateResidentWithUIN($$personaFilePath,$$uin1)"
+		},
+		"Step-19": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$updateTemplate=e2e_getPacketTemplate(UPDATE/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-20": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid3=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$updateTemplate)"
+		},
+		"Step-21": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid3)"
+		},
+		"Step-22": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin3=e2e_getUINByRid($$rid3)"
+		},
+		"Step-23": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$rid3,PRINT_SERVICE,PROCESSED)"
+		},
+		"Step-24": {
+			"Description": "Checks uin after updating it",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckUpdatedUIN($$uin1,$$uin3)"
+		}
+	},
+	{
 		"Scenario": "AFTER_SUITE",
 		"Tag": "Postive_Test",
 		"Persona": "ResidentMaleAdult",


### PR DESCRIPTION
DSL add new 2 scenarios
1.Resident walks into reg-center and generates UIN1, same person tried to get UIN2 and UIN3 (based on MV decision), resident tries to update UIN1 with biometrics and uploads packet and updates successfully.
 2.Resident walks into reg-center and generated UIN1, same person tried to get UIN 2 and failed to UIN as per MV decision, resident tries to update biometrics with UIN1 and updates successfully.