### PR TITLE
MOSIP-31607-add new method to deactivate uin with new scenario

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DeactivateUIN.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DeactivateUIN.java
@@ -1,0 +1,111 @@
+package io.mosip.testrig.dslrig.ivv.e2e.methods;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+import io.mosip.testrig.apirig.idrepo.testscripts.UpdateIdentity;
+import io.mosip.testrig.apirig.dto.TestCaseDTO;
+import io.mosip.testrig.apirig.testrunner.BaseTestCase;
+import io.mosip.testrig.apirig.testrunner.JsonPrecondtion;
+import io.mosip.testrig.apirig.utils.AdminTestException;
+import io.mosip.testrig.apirig.utils.AuthenticationTestException;
+import io.mosip.testrig.dslrig.ivv.core.base.StepInterface;
+import io.mosip.testrig.dslrig.ivv.core.exceptions.FeatureNotSupportedError;
+import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
+import io.mosip.testrig.dslrig.ivv.orchestrator.BaseTestCaseUtil;
+import io.mosip.testrig.dslrig.ivv.orchestrator.dslConfigManager;
+
+public class DeactivateUIN extends BaseTestCaseUtil implements StepInterface {
+	
+	static Logger logger = Logger.getLogger(DeactivateUIN.class);
+	private static final String DEACTIVATEUIN = "idaData/DeactivateUIN/UpdateIdentity.yml";
+
+	static {
+		if (dslConfigManager.IsDebugEnabled())
+			logger.setLevel(Level.ALL);
+		else
+			logger.setLevel(Level.ERROR);
+	}
+
+	UpdateIdentity  updateIdentity  = new UpdateIdentity();
+
+	@Override
+	public void run() throws RigInternalError, FeatureNotSupportedError {
+		String uins = null;
+		List<String> uinList = null;
+		String emailId = "";
+		Object[] casesListUIN = null;
+
+		if (step.getParameters().isEmpty() || step.getParameters().size() < 1) {
+			logger.error("Parameter is  missing from DSL step");
+			this.hasError = true;
+			throw new RigInternalError("Modality paramter is  missing in step: " + step.getName());
+		}
+		if (step.getParameters().size() == 2) {
+			emailId = step.getParameters().get(1);
+			if (emailId.startsWith("$$")) {
+				emailId = step.getScenario().getVariables().get(emailId);
+			}
+			if (emailId == null || (emailId != null && emailId.isBlank())) {
+				throw new FeatureNotSupportedError("Email id is Empty hence we cannot perform deactivate uin");
+
+			}
+			
+		}
+		if (step.getParameters().size() == 2 && step.getParameters().get(0).startsWith("$$")) {
+			uins = step.getParameters().get(0);
+			if (uins.startsWith("$$")) {
+				uins = step.getScenario().getVariables().get(uins);
+				uinList = new ArrayList<>(Arrays.asList(uins.split("@@")));
+			}
+		} else
+			uinList = new ArrayList<>(step.getScenario().getUinPersonaProp().stringPropertyNames());
+
+		
+
+		if (BaseTestCase.getSupportedIdTypesValueFromActuator().contains("UIN")
+				|| BaseTestCase.getSupportedIdTypesValueFromActuator().contains("uin")) {
+
+			casesListUIN = updateIdentity.getYmlTestData(DEACTIVATEUIN);
+
+		}
+
+
+		else {
+			casesListUIN = updateIdentity.getYmlTestData(DEACTIVATEUIN);
+		}
+
+		for (String uin : uinList) {
+			Object[] testObj = updateIdentity.getYmlTestData(DEACTIVATEUIN);
+			TestCaseDTO test = (TestCaseDTO) testObj[0];
+			String input = test.getInput();
+			
+			input = JsonPrecondtion.parseAndReturnJsonContent(input, uin, "UIN");
+			input = JsonPrecondtion.parseAndReturnJsonContent(input, emailId, "email");
+			
+
+			if (casesListUIN != null) {
+				for (Object object : casesListUIN) {
+					test.setInput(input);
+					try {
+						updateIdentity.test(test);
+					} catch (AuthenticationTestException e) {
+						this.hasError = true;
+						logger.error(e.getMessage());
+						throw new RigInternalError("DEACTIVATEUIN failed ");
+					} catch (AdminTestException e) {
+						this.hasError = true;
+						logger.error(e.getMessage());
+						throw new RigInternalError("DEACTIVATEUIN failed");
+					}
+				}
+			}
+
+		}
+
+	}
+}

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/dslConfigManager.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/dslConfigManager.java
@@ -47,6 +47,10 @@ public class dslConfigManager extends ConfigManager {
 	public static String getpacketUtilityBaseUrl() {
 		return ConfigManager.getproperty("packetUtilityBaseUrl");
 	}
+	
+	public static String getEsignetMockBaseURL() { 
+		return getproperty("esignetMockBaseURL");
+	}
 
 	public static synchronized boolean isInTobeSkippedList(String stringToFind) {
 		String toSkippedList = ConfigManager.getproperty("servicesNotDeployed");

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -21332,6 +21332,248 @@
 		}
 	},
 	{
+		"Scenario": "188",
+		"Tag": "Postive_Test",
+		"Persona": "ResidentMaleAdult",
+		"Group": "NA",
+		"Description": "A differently abled resident walk-ins to registration center completes the process with both thumbs as exception and gets UIN card Later performs biometric authentication using IRIS Face Fingerprint that are exception and with fingerprints that are not marked as exception",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Details can be found in in-line comments on the parameters",
+			"Return Value": "pre-requiste details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Enviornment and user details. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false/*GUARDIAN_FLAG*/,Male)"
+		},
+		"Step-5": {
+			"Description": "Updates persona with Biometric exception",
+			"Input Parameters": "Persona and exception modalities details.",
+			"Return Value": "NA",
+			"Action": "e2e_UpdateBioExceptionInPersona($$personaFilePath,Finger:Left Thumb@@Finger:Right Thumb)"
+		},
+		"Step-6": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-7": {
+			"Description": "Genertes and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-8": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid)"
+		},
+		"Step-9": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin=e2e_getUINByRid($$rid)"
+		},
+		"Step-10": {
+			"Description": "Gets Email ID configuired for the UIN",
+			"Input Parameters": "UIN",
+			"Return Value": "Email ID",
+			"Action": "$$email=e2e_getEmailByUIN($$uin)"
+		},
+		"Step-11": {
+			"Description": "Waits for given period in seconds",
+			"Input Parameters": "Time period in seconds to wait",
+			"Return Value": "NA",
+			"Action": "e2e_wait(90)"
+		},
+		"Step-12": {
+			"Description": "Generated VID for the given UIN",
+			"Input Parameters": "UIN and other can be found in parameters in-line commnets",
+			"Return Value": "VID",
+			"Action": "$$vid=e2e_generateVID(Perpetual,$$uin,$$email)"
+		},
+		"Step-13": {
+			"Description": "Waits for given period in seconds",
+			"Input Parameters": "Time period in seconds to wait",
+			"Return Value": "NA",
+			"Action": "e2e_wait(90)"
+		},
+		"Step-14": {
+			"Description": "Performs biometric authentication",
+			"Input Parameters": "Modalitiy UIN VID and persona file path",
+			"Return Value": "NA",
+			"Action": "e2e_bioAuthentication(rightThumbDevice,$$uin,$$vid,$$personaFilePath,ERROR)"
+		},
+		"Step-15": {
+			"Description": "Performs biometric authentication",
+			"Input Parameters": "Modalitiy UIN VID and persona file path",
+			"Return Value": "NA",
+			"Action": "e2e_bioAuthentication(LeftIris,$$uin,$$vid,$$personaFilePath)"
+		},
+		"Step-16": {
+			"Description": "Performs biometric authentication",
+			"Input Parameters": "Modalitiy UIN VID and persona file path",
+			"Return Value": "NA",
+			"Action": "e2e_bioAuthentication(faceDevice,$$uin,$$vid,$$personaFilePath)"
+		}, 
+		"Step-17": {
+			"Description": "Performs biometric authentication",
+			"Input Parameters": "Modalitiy UIN VID and persona file path",
+			"Return Value": "NA",
+			"Action": "e2e_bioAuthentication(leftLittleDevice,$$uin,$$vid,$$personaFilePath)"
+		}
+	},
+	{
+		"Scenario": "189",
+		"Tag": "Postive_Test",
+		"Persona": "ResidentFemaleAdult",
+		"Group": "Adult_New",
+		"Description": "User creates UIN through reg center then deactivates it in IDRepo then create an update packet to see if it is rejected at packet validator stage",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Details can be found in in-line comments on the parameters",
+			"Return Value": "pre-requiste details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Enviornment and user details. Other prarameters details can be found in-line",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false,Female)"
+		},
+		"Step-5": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-6": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-7": {
+			"Description": "Checkes the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid)"
+		},
+		"Step-8": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin=e2e_getUINByRid($$rid)"
+		},
+		"Step-9": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$rid,PRINT_SERVICE,PROCESSED)"
+		},
+		"Step-10": {
+			"Description": "Compares generated packet tags against on server packet tages",
+			"Input Parameters": "RID",
+			"Return Value": "NA",
+			"Action": "e2e_CheckTags($$rid)"
+		},
+		"Step-11": {
+			"Description": "Gets Email ID configuired for the UIN",
+			"Input Parameters": "UIN",
+			"Return Value": "Email ID",
+			"Action": "$$email=e2e_getEmailByUIN($$uin)"
+		},
+		"Step-12": {
+			"Description": "deactive uin",
+			"Input Parameters": "UIN and Email ID",
+			"Return Value": "Request ID",
+			"Action": "e2e_deactivateUIN($$uin,$$email)"
+		},
+		"Step-13": {
+			"Description": "Waits for given period in seconds",
+			"Input Parameters": "Time period in seconds to wait",
+			"Return Value": "NA",
+			"Action": "e2e_wait(90)"
+		},
+		"Step-14": {
+			"Description": "Updates Demo graphic details and biometric in the persona file",
+			"Input Parameters": "Data to update and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_updateDemoOrBioDetails(iris,0,0,$$personaFilePath)"
+		},
+		"Step-15": {
+			"Description": "Updates persona with UIN",
+			"Input Parameters": "Persona file path and UIN",
+			"Return Value": "NA",
+			"Action": "e2e_updateResidentWithUIN($$personaFilePath,$$uin)"
+		},
+		"Step-16": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$updateTemplate=e2e_getPacketTemplate(UPDATE/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-17": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid2=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$updateTemplate)"
+		},
+		"Step-18": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(REREGISTER/*PACKET_STATUS*/,$$rid2)"
+		},
+		"Step-19": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$rid2,VALIDATE_PACKET,REJECTED)"
+		}
+	},
+	{
 		"Scenario": "AFTER_SUITE",
 		"Tag": "Postive_Test",
 		"Persona": "ResidentMaleAdult",

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DeactivateUIN/UpdateIdentity.yml
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DeactivateUIN/UpdateIdentity.yml
@@ -1,0 +1,21 @@
+UpdateIdentityForUin:
+  Auth_UpdateIdentityForUin_ACTIVATED_Positive_TRE_all_valid_smoke:
+      endPoint: /idrepository/v1/identity/
+      uniqueIdentifier: TC_IDA_UpdateIdentityForUin_01
+      description: Deactivate the activated UIN
+      role: idrepo
+      restMethod: patch
+      inputTemplate: idaData/DeactivateUIN/updateIdentity
+      outputTemplate: idaData/DeactivateUIN/updateIdentityResult
+      input: '{
+      "registrationId":"$RID$",
+      "UIN":"UIN",
+      "email": "EMAIL",
+      "status": "DEACTIVATED",
+      "dateOfBirth": "1970/07/08",
+      "requesttime": "$TIMESTAMP$",
+      "version": "v1"
+      }'
+      output: '{
+    "status": "DEACTIVATED"
+}'

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DeactivateUIN/updateIdentity.hbs
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DeactivateUIN/updateIdentity.hbs
@@ -1,0 +1,15 @@
+{
+    "id": "mosip.id.update",
+    "request": {
+        "registrationId": "{{registrationId}}",
+        "status": "{{status}}",
+        "identity": {
+            "IDSchemaVersion": $SCHEMAVERSION$,
+            "email": "{{email}}",
+            "dateOfBirth": "{{dateOfBirth}}",
+            "UIN": "{{UIN}}"
+		  }
+    },
+    "requesttime": "{{requesttime}}",
+    "version": "{{version}}"
+}                                                                                                                     

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DeactivateUIN/updateIdentityResult.hbs
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DeactivateUIN/updateIdentityResult.hbs
@@ -1,0 +1,12 @@
+{
+    "id": "$IGNORE$",
+    "version": "$IGNORE$",
+    "responsetime": "$IGNORE$",
+    "metadata": "$IGNORE$",
+    "response": {
+        "status": "{{status}}",
+        "identity": "$IGNORE$",
+        "documents": "$IGNORE$"
+    },
+    "errors": []
+}


### PR DESCRIPTION
Added new scenario
Scenario 1:
1. Create a new packet and generate a UIN through regproc
2. Deactivate the UIN using the idrepo API
3. Create a update packet for that UIN and expect that packet to be rejected at packet validator stage