### PR TITLE
MOSIP-31607-Impalement reprocess functionality in DSL with scenarios

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/ReprocessPacket.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/ReprocessPacket.java
@@ -1,10 +1,14 @@
 package io.mosip.testrig.dslrig.ivv.e2e.methods;
 
+import java.util.Map;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import io.mosip.testrig.apirig.dbaccess.DBManager;
+import io.mosip.testrig.apirig.utils.ConfigManager;
 import io.mosip.testrig.dslrig.ivv.core.base.StepInterface;
 import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
 import io.mosip.testrig.dslrig.ivv.orchestrator.BaseTestCaseUtil;
@@ -20,42 +24,46 @@ public class ReprocessPacket extends BaseTestCaseUtil implements StepInterface {
 		else
 			logger.setLevel(Level.ERROR);
 	}
-
+	
 	@Override
 	public void run() throws RigInternalError {
+	    String rid = null;
 
-		JSONObject myJSONObject = null;
-		String rid = null;
-		Boolean flag = false;
+	    if (step.getParameters().size() >= 1) {
+	        rid = step.getScenario().getVariables().get(step.getParameters().get(0));
+	    }
+	    
+	    JSONObject jsonReq = new JSONObject();
+	    jsonReq.put("rid", rid);
+	    jsonReq.put("workflowInstanceId", getWorkflowInstanceId(rid));
 
-		if (step.getParameters().size() > 1) {
-			rid = step.getScenario().getVariables().get(step.getParameters().get(0));
-			flag = Boolean.parseBoolean(step.getParameters().get(1));
+	    Response response = postRequest(baseUrl + props.getProperty("reprocessPacket"), jsonReq.toString(), "Reprocess the rid", step);
 
-		}
+	    String responseBody = response.getBody().asString();
+	    logger.info("Response Body: " + responseBody);
 
-		JSONObject jsonReq = new JSONObject();
-		jsonReq.put("rid", rid);
-		jsonReq.put("reg_type", "NEW");
+	    // Validate the expected response format
+	    JSONObject res = new JSONObject(responseBody);
+	    
+	    if (!res.has("status")) {
+	        logger.error("RESPONSE ERROR: 'status' field is missing in response: " + responseBody);
+	        throw new RuntimeException("ERROR: Expected 'status' field is missing in the response.");
+	    }
 
-		Response response = postRequest(baseUrl + props.getProperty("reprocessPacket"), jsonReq.toString(),
-				"Reprocess the rid", step);
+	    String expectedStatusMessage = "Packet with registrationId '" + rid + "' has been forwarded to next stage";
+	    String actualStatusMessage = res.getString("status").replace("\"", ""); // Remove escaped quotes if present
 
-		JSONObject res = new JSONObject(response.getBody().asString());
-		JSONArray arr = res.getJSONObject("response").getJSONArray("packetStatusUpdateList");
-		for (Object myObject : arr) {
-			myJSONObject = (JSONObject) myObject;
+	    if (!actualStatusMessage.equals(expectedStatusMessage)) {
+	        logger.error("ERROR: Expected status message not found. Actual: " + actualStatusMessage);
+	        throw new RuntimeException("ERROR: Expected status message not received. Actual: " + actualStatusMessage);
+	    }
+	}
+	
+	public static String  getWorkflowInstanceId(String RID) {
+		String sqlQuery = "SELECT * FROM regprc.registration where reg_id='"+RID+"'";
 
-		}
-		logger.info(res.toString());
-		if (flag.equals(true) && myJSONObject != null) {
-			logger.info("RESPONSE= contains");
-			logger.info("subStatusCode= " + myJSONObject.getString("subStatusCode"));
-
-		} else {
-			logger.error("RESPONSE= doesn't contain" + arr);
-			throw new RuntimeException("RESPONSE= doesn't contain");
-		}
-
+		Map<String, Object> response = DBManager
+				.executeQueryAndGetRecord(ConfigManager.getproperty("audit_default_schema"), sqlQuery);
+		return (String) response.get("workflow_instance_id");
 	}
 }

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
@@ -43,6 +43,7 @@ uploaddocument=preregistration/v1/documents/
 updatePreRegStatus=preregistration/v1/applications/prereg/status/
 mosip.test.prereg.centerid=10005
 ridStageStatus=v1/admin/packetstatusupdate
+audit_db_schema=regprc
 
 # supported values are 0 ,1, 2 based on number of env languages
 langselect=0

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -21574,6 +21574,109 @@
 		}
 	},
 	{
+		"Scenario": "190",
+		"Tag": "Postive_Test",
+		"Persona": "ResidentFemaleAdult",
+		"Group": "Adult_New",
+		"Description": "User creates UIN through reg center then deactivates it in IDRepo then reprocess the packet to see if it is rejected at packet validator stage",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Details can be found in in-line comments on the parameters",
+			"Return Value": "pre-requiste details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Enviornment and user details. Other prarameters details can be found in-line",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false,Female)"
+		},
+		"Step-5": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-6": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-7": {
+			"Description": "Checkes the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid)"
+		},
+		"Step-8": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin=e2e_getUINByRid($$rid)"
+		},
+		"Step-9": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$rid,PRINT_SERVICE,PROCESSED)"
+		},
+		"Step-10": {
+			"Description": "Compares generated packet tags against on server packet tages",
+			"Input Parameters": "RID",
+			"Return Value": "NA",
+			"Action": "e2e_CheckTags($$rid)"
+		},
+		"Step-11": {
+			"Description": "Gets Email ID configuired for the UIN",
+			"Input Parameters": "UIN",
+			"Return Value": "Email ID",
+			"Action": "$$email=e2e_getEmailByUIN($$uin)"
+		},
+		"Step-12": {
+			"Description": "deactive uin",
+			"Input Parameters": "UIN and Email ID",
+			"Return Value": "Request ID",
+			"Action": "e2e_deactivateUIN($$uin,$$email)"
+		},
+		"Step-13": {
+			"Description": "Compares generated packet tags against on server packet tages",
+			"Input Parameters": "RID",
+			"Return Value": "NA",
+			"Action": "e2e_reprocessPacket($$rid)"
+		},
+		"Step-14": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(REREGISTER/*PACKET_STATUS*/,$$rid)"
+		},
+		"Step-15": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$rid,UIN_GENERATOR,REJECTED)"
+		}
+	},
+	{
 		"Scenario": "AFTER_SUITE",
 		"Tag": "Postive_Test",
 		"Persona": "ResidentMaleAdult",

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/test-orchestrator_mz.properties
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/test-orchestrator_mz.properties
@@ -64,3 +64,4 @@ getPacketTagsInfo=/commons/v1/packetmanager/info
 clearDeviceCertCache=/clearDeviceCertCache
 uploadDeviceCert=/uploadDeviceCert
 resetContextData=/resetContextData
+reprocessPacket=/packet/reprocess

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/PacketController.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/PacketController.java
@@ -22,6 +22,7 @@ import io.mosip.testrig.dslrig.dataprovider.util.DataProviderConstants;
 import io.mosip.testrig.dslrig.dataprovider.util.RestClient;
 import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
 import io.mosip.testrig.dslrig.packetcreator.dto.PacketCreateDto;
+import io.mosip.testrig.dslrig.packetcreator.dto.PacketReprocessDto;
 import io.mosip.testrig.dslrig.packetcreator.dto.PreRegisterRequestDto;
 import io.mosip.testrig.dslrig.packetcreator.dto.RidSyncReqRequestDto;
 import io.mosip.testrig.dslrig.packetcreator.dto.RidSyncReqResponseDTO;
@@ -265,6 +266,18 @@ public class PacketController {
 		} catch (Exception ex) {
 			logger.error("createPacket", ex);
 			return ex.getMessage();
+		}
+	}
+	
+	@Operation(summary = "Reprocess the packet")
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Successfully Reprocessed the packet") })
+	@PostMapping(value = "/packet/reprocess/{contextKey}")
+	public @ResponseBody String packetReprocess(@RequestBody PacketReprocessDto requestDto,
+			@PathVariable("contextKey") String contextKey) throws Exception {
+		try {
+			return packetSyncService.reprocessPacket(requestDto.getRID() ,requestDto.getWorkflowInstanceId(), contextKey);
+		} catch (Exception e) {
+			return e.getMessage();
 		}
 	}
 

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/PacketController.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/PacketController.java
@@ -276,9 +276,10 @@ public class PacketController {
 			@PathVariable("contextKey") String contextKey) throws Exception {
 		try {
 			return packetSyncService.reprocessPacket(requestDto.getRID() ,requestDto.getWorkflowInstanceId(), contextKey);
-		} catch (Exception e) {
-			return e.getMessage();
+		}catch (Exception ex) {
+			logger.error("get tags", ex);
 		}
+		return "{\"Failed\"}";
 	}
 
 	/*

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/dto/PacketReprocessDto.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/dto/PacketReprocessDto.java
@@ -1,0 +1,10 @@
+package io.mosip.testrig.dslrig.packetcreator.dto;
+
+import lombok.Data;
+
+@Data
+public class PacketReprocessDto {
+ private String RID;
+ private String workflowInstanceId;
+	
+}

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
@@ -1517,5 +1517,25 @@ public class PacketSyncService {
 		return MosipDataSetup.deleteMockAbisExpectations(contextKey);
 
 	}
+	
+	public String reprocessPacket(String rid,String workflowInstanceId,String contextKey) throws Exception {
+		String url = baseUrl + "registrationprocessor/v1/securezone/notification";
+	    JSONObject requestBody = new JSONObject();
+	    requestBody.put("reg_type", "NEW");
+	    requestBody.put("rid", rid);
+	    requestBody.put("isValid", true);
+	    requestBody.put("internalError", false);
+	    requestBody.put("messageBusAddress", JSONObject.NULL);
+	    requestBody.put("retryCount", JSONObject.NULL);
+	    requestBody.put("tags", JSONObject.NULL);
+	    requestBody.put("lastHopTimestamp", JSONObject.NULL);
+	    requestBody.put("source", JSONObject.NULL);
+	    requestBody.put("iteration", 1);
+	    requestBody.put("workflowInstanceId", workflowInstanceId);
+
+	    JSONObject response = RestClient.post(url,requestBody,"regproc", contextKey);
+	    
+	    return response.toString();
+	}
 
 }


### PR DESCRIPTION
New scenarios related to deactivated UIN to be added to the DSL
Scenario :
1. Create a new packet and generate a UIN through regproc
2. Deactivate the UIN using the idrepo API
3. Reprocess the packet from beginning and expect that packet to be rejected at the UIN generator stage