### PR TITLE
MOSIP-33993- config clean up

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
@@ -17,7 +17,7 @@ scenariosToExecute=
 threadCount=
 
 # supported values yes or no ,local run make it no
-push-reports-to-s3 = no
+push-reports-to-s3 = yes
 
 mountPathForScenario=D:/centralized/mountvolume
 


### PR DESCRIPTION
push-reports-to-s3 = yes ---We don’t need to expose this property. Make this value as yes. If someone wants to run their local sys, they will change the property