### PR TITLE
MOSIP-41128-Fixed packet signature verification

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/Orchestrator.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/Orchestrator.java
@@ -467,19 +467,19 @@ public class Orchestrator {
 				Reporter.log(e.getMessage());
 				throw new SkipException(e.getMessage());
 			} catch (ClassNotFoundException e) {
-				extentTest.error(identifier + " - ClassNotFoundException --> " + e.getMessage());
+				extentTest.fail(identifier + " - ClassNotFoundException --> " + e.getMessage());
 				logger.error(e.getMessage());
 				updateRunStatistics(scenario);
 				Assert.assertTrue(false);
 				return;
 			} catch (IllegalAccessException e) {
-				extentTest.error(identifier + " - IllegalAccessException --> " + e.getMessage());
+				extentTest.fail(identifier + " - IllegalAccessException --> " + e.getMessage());
 				logger.error(e.getMessage());
 				updateRunStatistics(scenario);
 				Assert.assertTrue(false);
 				return;
 			} catch (InstantiationException e) {
-				extentTest.error(identifier + " - InstantiationException --> " + e.getMessage());
+				extentTest.fail(identifier + " - InstantiationException --> " + e.getMessage());
 				logger.error(e.getMessage());
 				updateRunStatistics(scenario);
 				Assert.assertTrue(false);
@@ -488,14 +488,14 @@ public class Orchestrator {
 				if (scenario.getId().equals("0")) {
 					beforeSuiteFailed = true;
 				}
-				extentTest.error(identifier + " - RigInternalError --> " + e.getMessage());
+				extentTest.fail(identifier + " - RigInternalError --> " + e.getMessage());
 				logger.error(e.getMessage());
 				Reporter.log(e.getMessage());
 				updateRunStatistics(scenario);
 				Assert.assertTrue(false);
 				return;
 			} catch (RuntimeException e) {
-				extentTest.error(identifier + " - RuntimeException --> " + e.getMessage());
+				extentTest.fail(identifier + " - RuntimeException --> " + e.getMessage());
 				logger.error(e.getMessage());
 				updateRunStatistics(scenario);
 				Assert.assertTrue(false);

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -711,9 +711,8 @@ public class PacketMakerService {
 			encryptedHash = org.apache.commons.codec.binary.Base64.encodeBase64URLSafeString(
 					messageDigest.digest(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + ".zip"))));
 
-		String signature = Base64.getEncoder().encodeToString(
+		String signature = Base64.getUrlEncoder().encodeToString(
 				cryptoUtil.sign(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + UNENCZIP)), contextKey));
-
 		Path src = Path.of(containerRootFolder + UNENCZIP);
 		Path destination = Path.of(
 				VariableManager.getVariableValue(contextKey, MOUNTPATH).toString()


### PR DESCRIPTION
Set packetmanager.packet.signature.disable-verification=false in the application-default.properties file and restart the Packet Manager pod to enable packet signature verification.
Mark test case as fail in extent report if it's giving error