### PR TITLE
MOSIP-29153-Reduce time of DSL execution

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/UploadDeviceCertificate.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/UploadDeviceCertificate.java
@@ -8,6 +8,7 @@ import java.util.Base64;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
+import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.dslrig.ivv.core.base.StepInterface;
 import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
 import io.mosip.testrig.dslrig.ivv.orchestrator.BaseTestCaseUtil;
@@ -34,7 +35,7 @@ public class UploadDeviceCertificate extends BaseTestCaseUtil implements StepInt
 			certsDir = dslConfigManager.getauthCertsPath();
 		}
 
-		String p12 = certsDir + File.separator + "DSL-IDA-" + dslConfigManager.getTargetEnvName() + File.separator
+		String p12 = certsDir + File.separator + "DSL-IDA-" + BaseTestCase.ApplnURI.replace("https://", "") + File.separator
 				+ "device-partner.p12";
 		File file = new File(p12);
 

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/BiometricDataProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/BiometricDataProvider.java
@@ -1005,13 +1005,13 @@ public class BiometricDataProvider {
 				// otherwise pick the impression of same of scenario number
 				int impressionToPick = (currentScenarioNumber < numberOfSubfolders) ? currentScenarioNumber
 						: randomNumber;
-				FingerprintVariationGenerator.fingerprintVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
+				dirPath = FingerprintVariationGenerator.fingerprintVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
 
 				RestClient.logInfo(contextKey, "currentScenarioNumber=" + currentScenarioNumber + " numberOfSubfolders="
 						+ numberOfSubfolders + " impressionToPick=" + impressionToPick);
 
 
-				List<File> firstSet = CommonUtil.listFiles(dirPath + "/output/" + currentScenarioNumber + "/" + String.format("/Impression_%d/fp_1/", impressionToPick));
+				List<File> firstSet = CommonUtil.listFiles(dirPath + "/" + String.format("/Impression_%d/fp_1/", impressionToPick));
 
 
 				String[] fingerPrints = new String[10];
@@ -1042,10 +1042,11 @@ public class BiometricDataProvider {
 				data.setFingerPrint(fingerPrints);
 				data.setFingerHash(fingerPrintHash);
 				data.setFingerRaw(fingerPrintRaw);
-
+				CommonUtil.deleteOldTempDir(dirPath);
 			}
 
 		}
+		
 		return data;
 	}
 
@@ -1085,9 +1086,9 @@ public class BiometricDataProvider {
 		randomNumber = (int) (Math.random() * (max - min)) + min;
 		int impressionToPick = (currentScenarioNumber < numberOfSubfolders) ? currentScenarioNumber : randomNumber;
 
-		FingerprintVariationGenerator.fingerprintVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
+		dirPath = FingerprintVariationGenerator.fingerprintVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
 
-		List<File> firstSet = CommonUtil.listFiles(dirPath + "/output/" + currentScenarioNumber + "/" + String.format("/Impression_%d/fp_1/", impressionToPick));
+		List<File> firstSet = CommonUtil.listFiles(dirPath + "/" + String.format("/Impression_%d/fp_1/", impressionToPick));
 
 		String[] fingerPrints = new String[10];
 		String[] fingerPrintHash = new String[10];
@@ -1117,6 +1118,7 @@ public class BiometricDataProvider {
 		data.setFingerPrint(fingerPrints);
 		data.setFingerHash(fingerPrintHash);
 		data.setFingerRaw(fingerPrintRaw);
+		CommonUtil.deleteOldTempDir(dirPath);
 
 		return data;
 	}
@@ -1261,10 +1263,10 @@ public class BiometricDataProvider {
 			// one
 			// otherwise pick the impression of same of scenario number
 			int impressionToPick = (currentScenarioNumber < numberOfSubfolders) ? currentScenarioNumber : randomNumber;
-			IrisVariationGenerator.irisVariationGenerator(contextKey,currentScenarioNumber,impressionToPick);
+			srcPath = IrisVariationGenerator.irisVariationGenerator(contextKey,currentScenarioNumber,impressionToPick);
 
-			File folder = new File(srcPath + "/output/"+currentScenarioNumber+"/" + String.format("%03d", impressionToPick));
-			logger.info(srcPath + "/output/"+currentScenarioNumber+"/" + String.format("%03d", impressionToPick));
+			File folder = new File(srcPath+"/" + String.format("%03d", impressionToPick));
+			logger.info(srcPath+"/" + String.format("%03d", impressionToPick));
 
 			File[] listOfFiles = folder.listFiles();
 			//			listOfFiles=getRandomIrisVariation(listOfFiles);
@@ -1283,8 +1285,8 @@ public class BiometricDataProvider {
 			if (rightbmp == null) {
 				rightbmp = leftbmp;
 			}
-			String fPathL = srcPath +"/output/"+currentScenarioNumber + "/" + String.format("%03d", impressionToPick) + "/" + leftbmp;
-			String fPathR = srcPath +"/output/"+currentScenarioNumber + "/" + String.format("%03d", impressionToPick) + "/" + rightbmp;
+			String fPathL = srcPath + "/" + String.format("%03d", impressionToPick) + "/" + leftbmp;
+			String fPathR = srcPath + "/" + String.format("%03d", impressionToPick) + "/" + rightbmp;
 			String leftIrisData = "";
 			String rightIrisData = "";
 			String irisHash = "";
@@ -1314,6 +1316,7 @@ public class BiometricDataProvider {
 			m.setRawLeft(fldata);
 			m.setRawRight(frdata);
 			retVal.add(m);
+			CommonUtil.deleteOldTempDir(srcPath);
 		}
 
 		return retVal;
@@ -1346,9 +1349,9 @@ public class BiometricDataProvider {
 		randomNumber = (int) (Math.random() * (max - min)) + min;
 		int impressionToPick = (currentScenarioNumber < numberOfSubfolders) ? currentScenarioNumber : randomNumber;
 
-		IrisVariationGenerator.irisVariationGenerator(contextKey,currentScenarioNumber,impressionToPick);
+		srcPath = IrisVariationGenerator.irisVariationGenerator(contextKey,currentScenarioNumber,impressionToPick);
 
-		File folder = new File(srcPath + "/output/"+currentScenarioNumber+"/" + String.format("%03d", impressionToPick));
+		File folder = new File(srcPath +"/" + String.format("%03d", impressionToPick));
 
 		File[] listOfFiles = folder.listFiles();
 		//		listOfFiles=getRandomIrisVariation(listOfFiles);
@@ -1366,8 +1369,8 @@ public class BiometricDataProvider {
 		if (rightbmp == null) {
 			rightbmp = leftbmp;
 		}
-		String fPathL = srcPath +"/output/"+currentScenarioNumber + "/" + String.format("%03d", impressionToPick) + "/" + leftbmp;
-		String fPathR = srcPath +"/output/"+currentScenarioNumber + "/" + String.format("%03d", impressionToPick) + "/" + rightbmp;
+		String fPathL = srcPath + "/" + String.format("%03d", impressionToPick) + "/" + leftbmp;
+		String fPathR = srcPath + "/" + String.format("%03d", impressionToPick) + "/" + rightbmp;
 
 		String leftIrisData = "";
 		String rightIrisData = "";
@@ -1398,7 +1401,7 @@ public class BiometricDataProvider {
 		m.setRawLeft(fldata);
 		m.setRawRight(frdata);
 		retVal.add(m);
-
+		CommonUtil.deleteOldTempDir(srcPath);
 		return retVal;
 	}
 
@@ -1432,9 +1435,9 @@ public class BiometricDataProvider {
 			randomNumber = (int) (Math.random() * (max - min)) + min;
 			int impressionToPick = (currentScenarioNumber < numberOfSubfolders) ? currentScenarioNumber : randomNumber;
 
-			FaceVariationGenerator.faceVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
+			dirPath=FaceVariationGenerator.faceVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
 
-			List<File> firstSet = CommonUtil.listFiles(dirPath+"/output/"+currentScenarioNumber + "/face_data/");
+			List<File> firstSet = CommonUtil.listFiles(dirPath + "/face_data/");
 			
 			List<File> filteredFiles = firstSet.stream().filter(file -> file.getName().contains("00"+impressionToPick)).toList();
 			BufferedImage img = null;
@@ -1452,7 +1455,7 @@ public class BiometricDataProvider {
 			bencoded = PhotoProvider.encodeFaceImageData(bData);
 
 			baos.close();
-
+			CommonUtil.deleteOldTempDir(dirPath);
 		} catch (Exception e) {
 
 			logger.error(e.getMessage());

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/FaceVariationGenerator.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/FaceVariationGenerator.java
@@ -43,7 +43,7 @@ public class FaceVariationGenerator {
     // Variable to store the combination of variations
     public static int faceVariations = 0;
 
-    public static void faceVariationGenerator(String contextKey,int currentScenarioNumber,int impressionToPick) throws IOException {
+    public static String faceVariationGenerator(String contextKey,int currentScenarioNumber,int impressionToPick) throws IOException {
 
         /// Provide folder where the base template image present
         String inputFaceTemplateDirectoryPath = System.getProperty("java.io.tmpdir")
@@ -54,6 +54,7 @@ public class FaceVariationGenerator {
 				+ VariableManager.getVariableValue(contextKey, "mosip.test.persona.facedatapath").toString()+"/output/"+currentScenarioNumber;
 
         generatefaceVariations(inputFaceTemplateDirectoryPath, outputUniqueFaceDataPath);
+		return outputUniqueFaceDataPath;
     }
 
     /**************************************************************

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/FingerprintVariationGenerator.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/FingerprintVariationGenerator.java
@@ -55,7 +55,7 @@ public class FingerprintVariationGenerator {
     // Variable to store the combination of variations
     public static int fingerPrintVariations = 0;
 
-    public static void fingerprintVariationGenerator(String contextKey,int currentScenarioNumber,int impressionToPick) throws IOException {
+    public static String fingerprintVariationGenerator(String contextKey,int currentScenarioNumber,int impressionToPick) throws IOException {
         /// Provide folder where the base template image present
         String inputFPTemplateDirectoryPath =  System.getProperty("java.io.tmpdir") + VariableManager
 				.getVariableValue(contextKey, "mosip.test.persona.fingerprintdatapath").toString()+"/"+String.format("/Impression_%d/fp_1/", impressionToPick);
@@ -65,6 +65,7 @@ public class FingerprintVariationGenerator {
 				.getVariableValue(contextKey, "mosip.test.persona.fingerprintdatapath").toString()+"/output/"+currentScenarioNumber;
 
         generateFingerprintVariations(inputFPTemplateDirectoryPath, outputUniqueFingerprintDataPath);
+		return outputUniqueFingerprintDataPath;
     }
 
 
@@ -83,7 +84,7 @@ public class FingerprintVariationGenerator {
 //                | SMOOTH_FINGERS | CURVED_FINGERS | STRAIGHT_FINGERS | STRONG_FINGERS | BLISTERED_FINGERS
 //                | DELICATE_FINGERS
 //                | SWOLLEN_FINGERS | SENSITIVE_FINGERS | STEADY_FINGERS);
-        setFPVariations(WET_FINGER);
+        setFPVariations(STEADY_FINGERS);
         try {
             // Get all file names in the directory and subdirectories
             List<String> fileNameAbsPaths = listFiles(inputFPTemplateDirectoryPath);
@@ -223,7 +224,7 @@ public class FingerprintVariationGenerator {
                     .get((j - 1) % activeVariations.size());
             BufferedImage fingerprintImageWithVariation = Variation.apply(fingerprintImage, j);
 
-            fingerprintImageWithVariation = postProcessFingerprint(fingerprintImageWithVariation);
+//            fingerprintImageWithVariation = postProcessFingerprint(fingerprintImageWithVariation);
 
             outputFingerprintPath = outputUniqueFingerprintDataRelativePath + "//" + FPPath
                     + strFingervariation + "_" + FileName;

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/IrisVariationGenerator.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/IrisVariationGenerator.java
@@ -60,7 +60,7 @@ public class IrisVariationGenerator {
     // Variable to store the combination of variations
     public static int irisVariations = 0;
 
-    public static void irisVariationGenerator(String contextKey,int currentScenarioNumber,int impressionToPick) {
+    public static String irisVariationGenerator(String contextKey,int currentScenarioNumber,int impressionToPick) {
         /// Provide folder where the base template image present
         String inputIRISTemplateDirectoryPath = System.getProperty("java.io.tmpdir")
 				+ VariableManager.getVariableValue(contextKey, "mosip.test.persona.irisdatapath").toString()+"/"+String.format("%03d", impressionToPick);
@@ -71,6 +71,7 @@ public class IrisVariationGenerator {
         logger.info("outputUniqueIRISDataPath : "+outputUniqueIRISDataPath);
 
         generateIRISVariations(inputIRISTemplateDirectoryPath, outputUniqueIRISDataPath);
+		return outputUniqueIRISDataPath;
     }
 
 

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PhotoProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PhotoProvider.java
@@ -56,12 +56,12 @@ public class PhotoProvider {
 			// otherwise pick the impression of same of scenario number
 			int impressionToPick = (currentScenarioNumber < numberOfSubfolders) ? currentScenarioNumber : randomNumber;
 			
-			FaceVariationGenerator.faceVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
+			dirPath = FaceVariationGenerator.faceVariationGenerator(contextKey, currentScenarioNumber, impressionToPick);
 			
 			logger.info("currentScenarioNumber=" + currentScenarioNumber + " numberOfSubfolders=" + numberOfSubfolders
 					+ " impressionToPick=" + impressionToPick);
 			
-			List<File> firstSet = CommonUtil.listFiles(dirPath+"/output/"+currentScenarioNumber + "/face_data/");
+			List<File> firstSet = CommonUtil.listFiles(dirPath + "/face_data/");
 			
 			List<File> filteredFiles = firstSet.stream().filter(file -> file.getName().contains("00"+impressionToPick)).toList();
 
@@ -96,6 +96,8 @@ public class PhotoProvider {
 			bencoded = encodeFaceImageData(bData);
 
 			baos.close();
+			CommonUtil.deleteOldTempDir(dirPath);
+
 
 		} catch (Exception e) {
 

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/CommonUtil.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/CommonUtil.java
@@ -318,4 +318,22 @@ public class CommonUtil {
 		boolean b = m.matches();
 
 	}
+	
+	 public static void deleteOldTempDir(String folderPath) throws IOException {
+	        Path tempPath = Paths.get(folderPath);
+	        if (Files.exists(tempPath)) {
+	            Files.walk(tempPath)
+	                .sorted((p1, p2) -> p2.compareTo(p1)) // Delete files first
+	                .forEach(path -> {
+	                    try {
+	                        Files.delete(path);
+	                        logger.debug("Deleted: {}", path);
+	                    } catch (IOException e) {
+	                        logger.error("❌ Failed to delete {}", path, e);
+	                        throw new RuntimeException(e);
+	                    }
+	                });
+	            logger.info("🗑️ Deleted old temp directory: {}", folderPath);
+	        }
+	    }
 }


### PR DESCRIPTION
1. Utilized a VM profiler to analyze execution time. Identified and commented out lines of code that were consuming significant time but were not essential, to enhance overall performance.
2.  After extracting data from the biometric variation file, the temporary file is deleted to conserve memory and maintain a clean working environment.
3.  Updated the code to use the same path for generating certificates as used for uploading them, ensuring consistency and reducing path-related configuration issues.