### PR TITLE
MOSIP-25639- Fixed Send OTP intermediate  issue 

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/SendOtp.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/SendOtp.java
@@ -24,23 +24,29 @@ public class SendOtp extends BaseTestCaseUtil implements StepInterface {
 //		Properties kernelprops = ConfigManager.propsKernel;
 		String emailId = dslConfigManager.getproperty("usePreConfiguredEmail");
 
+		if (emailId == null || emailId.trim().isEmpty() || emailId.equals("")) {
+			emailId = "email";
+		}
+
 		if (step.getParameters().isEmpty()) {
 			for (String resDataPath : step.getScenario().getResidentTemplatePaths().keySet()) {
-				packetUtility.requestOtp(resDataPath, step.getScenario().getCurrentStep(), emailId, step);
+				emailId = packetUtility.requestOtp(resDataPath, step.getScenario().getCurrentStep(), emailId, step);
 			}
 		} else if (!step.getParameters().isEmpty() && step.getParameters().size() == 1
 				&& !step.getParameters().get(0).startsWith("$$")) { // used for child packet processing
 			isForChildPacket = Boolean.parseBoolean(step.getParameters().get(0));
 			if (isForChildPacket && !step.getScenario().getGeneratedResidentData().isEmpty())
-				packetUtility.requestOtp(step.getScenario().getGeneratedResidentData().get(0),
+				emailId = packetUtility.requestOtp(step.getScenario().getGeneratedResidentData().get(0),
 						step.getScenario().getCurrentStep(), emailId, step);
 		} else {
 			String personaFilePath = step.getParameters().get(0); // "$$var=e2e_sendOtp($$personaFilePath)"
 			if (personaFilePath.startsWith("$$")) {
 				personaFilePath = step.getScenario().getVariables().get(personaFilePath);
-				packetUtility.requestOtp(personaFilePath, step.getScenario().getCurrentStep(), emailId, step);
+				emailId = packetUtility.requestOtp(personaFilePath, step.getScenario().getCurrentStep(), emailId, step);
 			}
 		}
+		if (step.getOutVarName() != null)
+			step.getScenario().getVariables().put(step.getOutVarName(), emailId);
 	}
 
 }

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/ValidateOtp.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/ValidateOtp.java
@@ -23,26 +23,28 @@ public class ValidateOtp extends BaseTestCaseUtil implements StepInterface {
 
 		Boolean isForChildPacket = false;
 //		Properties kernelprops=ConfigManager.propsKernel;
-		String emailId = dslConfigManager.getproperty("usePreConfiguredEmail");
+		if (step.getParameters().size() == 2) {
+			String emailId = step.getScenario().getVariables().get(step.getParameters().get(1));
 
-		if (step.getParameters().isEmpty()) {
-			// emailOrPhone =step.getParameters().get(0);
-			for (String resDataPath : step.getScenario().getResidentTemplatePaths().keySet()) {
-				packetUtility.verifyOtp(resDataPath, step.getScenario().getCurrentStep(), emailId, step,
-						OTPListener.getOtp(emailId));
-			}
-		} else if (!step.getParameters().isEmpty() && step.getParameters().size() == 1
-				&& !step.getParameters().get(0).startsWith("$$")) { // used for child packet processing
-			isForChildPacket = Boolean.parseBoolean(step.getParameters().get(0));
-			if (isForChildPacket && !step.getScenario().getGeneratedResidentData().isEmpty())
-				packetUtility.verifyOtp(step.getScenario().getGeneratedResidentData().get(0),
-						step.getScenario().getCurrentStep(), emailId, step, OTPListener.getOtp(emailId));
-		} else {
-			String personaFilePath = step.getParameters().get(0); // "$$var=e2e_validateOtp($$personaFilePath)"
-			if (personaFilePath.startsWith("$$")) {
-				personaFilePath = step.getScenario().getVariables().get(personaFilePath);
-				packetUtility.verifyOtp(personaFilePath, step.getScenario().getCurrentStep(), emailId, step,
-						OTPListener.getOtp(emailId));
+			if (step.getParameters().isEmpty()) {
+				// emailOrPhone =step.getParameters().get(0);
+				for (String resDataPath : step.getScenario().getResidentTemplatePaths().keySet()) {
+					packetUtility.verifyOtp(resDataPath, step.getScenario().getCurrentStep(), emailId, step,
+							OTPListener.getOtp(emailId));
+				}
+			} else if (!step.getParameters().isEmpty() && step.getParameters().size() == 1
+					&& !step.getParameters().get(0).startsWith("$$")) { // used for child packet processing
+				isForChildPacket = Boolean.parseBoolean(step.getParameters().get(0));
+				if (isForChildPacket && !step.getScenario().getGeneratedResidentData().isEmpty())
+					packetUtility.verifyOtp(step.getScenario().getGeneratedResidentData().get(0),
+							step.getScenario().getCurrentStep(), emailId, step, OTPListener.getOtp(emailId));
+			} else {
+				String personaFilePath = step.getParameters().get(0); // "$$var=e2e_validateOtp($$personaFilePath)"
+				if (personaFilePath.startsWith("$$")) {
+					personaFilePath = step.getScenario().getVariables().get(personaFilePath);
+					packetUtility.verifyOtp(personaFilePath, step.getScenario().getCurrentStep(), emailId, step,
+							OTPListener.getOtp(emailId));
+				}
 			}
 		}
 	}

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
@@ -299,7 +299,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 	    return templateResponse.getBody().asString();
 	}
 
-	public void requestOtp(String resFilePath, HashMap<String, String> map, String emailOrPhone, Scenario.Step step)
+	public String requestOtp(String resFilePath, HashMap<String, String> map, String emailOrPhone, Scenario.Step step)
 			throws RigInternalError {
 		String url = baseUrl + props.getProperty("sendOtpUrl") + emailOrPhone;
 		JSONObject jsonReq = new JSONObject();
@@ -311,6 +311,9 @@ public class PacketUtility extends BaseTestCaseUtil {
 			this.hasError = true;
 			throw new RigInternalError("Unable to Send OTP");
 		}
+
+		JSONObject json = new JSONObject(response.getBody().asString());
+		return json.getString("emailId");
 
 	}
 

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
@@ -42,8 +42,8 @@ mosip.test.temp=/packets/
 templateIDMeta=/profile_resource/templates_data/IDMetaInfo.json
 
 usePreConfiguredOtp=false
-usePreConfiguredEmail=prereg-dsl9@gmail.com
-otpTargetEmail=prereg-dsl9@gmail.com
+usePreConfiguredEmail=
+otpTargetEmail=
 preconfiguredOtp=111111
 email_otp=111111
 uploaddocument=preregistration/v1/documents/

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -334,13 +334,13 @@
 			"Description": "Generates OTP request",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$personaFilePath)"
+			"Action": "$$email=e2e_sendOtp($$personaFilePath)"
 		},
 		"Step-7": {
 			"Description": "Validates the OTP",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_validateOtp($$personaFilePath)"
+			"Action": "e2e_validateOtp($$personaFilePath,$$email)"
 		},
 		"Step-8": {
 			"Description": "Generates pre registration packet with given persona file",
@@ -2298,13 +2298,13 @@
 			"Description": "Generates OTP request",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$personaFilePath)"
+			"Action": "$$email=e2e_sendOtp($$personaFilePath)"
 		},
 		"Step-7": {
 			"Description": "Validates the OTP",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_validateOtp($$personaFilePath)"
+			"Action": "e2e_validateOtp($$personaFilePath,$$email)"
 		},
 		"Step-8": {
 			"Description": "Generates pre registration packet with given persona file",
@@ -4546,13 +4546,13 @@
 			"Description": "Generates OTP request",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$personaFilePath)"
+			"Action": "$$email=e2e_sendOtp($$personaFilePath)"
 		},
 		"Step-7": {
 			"Description": "Validates the OTP",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_validateOtp($$personaFilePath)"
+			"Action": "e2e_validateOtp($$personaFilePath,$$email)"
 		},
 		"Step-8": {
 			"Description": "Generates pre registration packet with given persona file",
@@ -6538,13 +6538,13 @@
 			"Description": "Generates OTP request",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$personaFilePath)"
+			"Action": "$$email=e2e_sendOtp($$personaFilePath)"
 		},
 		"Step-7": {
 			"Description": "<<<Step detailed description>>>",
 			"Input Parameters": "<<<Step inputs values details>>>",
 			"Return Value": "<<<Step output details>>>",
-			"Action": "e2e_validateOtp($$personaFilePath)"
+			"Action": "e2e_validateOtp($$personaFilePath,$$email)"
 		},
 		"Step-8": {
 			"Description": "<<<Step detailed description>>>",
@@ -8036,13 +8036,13 @@
 			"Description": "Generates OTP request",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$personaFilePath)"
+			"Action": "$$email=e2e_sendOtp($$personaFilePath)"
 		},
 		"Step-7": {
 			"Description": "Validates the OTP",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_validateOtp($$personaFilePath)"
+			"Action": "e2e_validateOtp($$personaFilePath,$$email)"
 		},
 		"Step-8": {
 			"Description": "Generates pre registration packet with given persona file",
@@ -8151,13 +8151,13 @@
 			"Description": "Generates OTP request",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$personaFilePath)"
+			"Action": "$$email=e2e_sendOtp($$personaFilePath)"
 		},
 		"Step-7": {
 			"Description": "Validates the OTP",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_validateOtp($$personaFilePath)"
+			"Action": "e2e_validateOtp($$personaFilePath,$$email)"
 		},
 		"Step-8": {
 			"Description": "Generates pre registration packet with given persona file",
@@ -8259,14 +8259,14 @@
 		"Step-6": {
 			"Description": "Generates OTP request",
 			"Input Parameters": "Persona file path",
-			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$personaFilePath)"
+			"Return Value": "email id",
+			"Action": "$$email=e2e_sendOtp($$personaFilePath)"
 		},
 		"Step-7": {
 			"Description": "Validates the OTP",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_validateOtp($$personaFilePath)"
+			"Action": "e2e_validateOtp($$personaFilePath,$$email)"
 		},
 		"Step-8": {
 			"Description": "Generates pre registration packet with given persona file",
@@ -13576,13 +13576,13 @@
 			"Description": "Sends OTP request",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_sendOtp($$childPersona)"
+			"Action": "$$email=e2e_sendOtp($$childPersona)"
 		},
 		"Step-14": {
 			"Description": "Validates OTP ",
 			"Input Parameters": "Persona file path",
 			"Return Value": "NA",
-			"Action": "e2e_validateOtp($$childPersona)"
+			"Action": "e2e_validateOtp($$childPersona,$$email)"
 		},
 		"Step-15": {
 			"Description": "Generates pre registration packet with given persona file",
@@ -16793,7 +16793,7 @@
 			"Description": "Sets the context for scenario execution",
 			"Input Parameters": "Enviornment and user details. Other prarameters details can be found in-line",
 			"Return Value": "NA",
-			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/,null/*PUT_SCENARIO_DETAILS_IN_CONTEXT*/,null/*CONSENT_FLAG*/,true/*SWITCH_CASE_FOR_SUPERVISOR_NAME*/)"
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/,null/*PUT_SCENARIO_DETAILS_IN_CONTEXT*/,null/*CONSENT_FLAG*/,false/*SWITCH_CASE_FOR_SUPERVISOR_NAME*/)"
 		},
 		"Step-3": {
 			"Description": "Performs health check of required server components to run end-to-end scenarios",
@@ -22674,7 +22674,7 @@
 		"Tag": "Postive_Test",
 		"Persona": "ResidentFemaleAdult",
 		"Group": "Adult_New",
-		"Description": "Resident walk-ins to registration center completes the process and gets UIN card",
+		"Description": "Resident walk-ins to registration center completes the process and gets UIN card later we perform crvs external packet death flow",
 		"Step-0": {
 			"Description": "Performs health check of given component",
 			"Input Parameters": "Keyword to check, only packetcreator is supported",

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
@@ -673,7 +673,7 @@ public class PacketSyncService {
 		for (String path : personaFilePath) {
 			ResidentModel resident = ResidentModel.readPersona(path);
 			ResidentPreRegistration preReg = new ResidentPreRegistration(resident);
-			builder.append(preReg.sendOtpTo(to, contextKey));
+			builder.append(preReg.sendOtpTo(resident,to, contextKey));
 
 		}
 		return builder.toString();


### PR DESCRIPTION
This PR addresses the issue where the "Send OTP" functionality was failing in subsequent scenarios due to a hardcoded email ID in the dsl.properties file.

**Issue Details:**
Previously, the email ID used for sending OTP was hardcoded in the DSL properties.
As a result, when the OTP was sent in one scenario, the second scenario would fail due to a conflict or reuse of the same email.

**Fix Implemented:**
Removed the hardcoded email ID dependency from the DSL configuration.
Updated the logic to dynamically generate or fetch a fresh/different email ID for each scenario.
Ensures that each test case sends the OTP using a unique email ID, preventing any overlap or failure.
This fix enhances the reusability and stability of OTP-related scenarios in the test suite.