### PR TITLE
MOSIP-31750-Fixed Failed to generate biometrics via mock mds intermittently during parallel DSL run

### DIFF
--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/BiometricDataProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/BiometricDataProvider.java
@@ -221,6 +221,7 @@ public class BiometricDataProvider {
 
 	public static MDSRCaptureModel regenBiometricViaMDS(ResidentModel resident, String contextKey, String purpose,
 			String qualityScore) throws Exception {
+		CentralizedMockSBI.stopSBI(contextKey);
 		BiometricDataModel biodata = null;
 		MDSRCaptureModel capture = null;
 


### PR DESCRIPTION
For the DSL step getPAcketTemplate() --- We are collating all the data for the packet to be uploaded ,which includes retrieving the bio metrics through mock mds . 
So before generating bio metric we are removing value from the local store 