### PR TITLE
MOSIP-44398-DSL SCNARIO-Resident updates demographic details, authentication with old details should fail

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DemoAuthentication.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DemoAuthentication.java
@@ -63,7 +63,7 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 		Object[] casesListVID = null;
 		Object[] casesListHandles = null;
 		String updateAgeFlag = null;
-		String  SceanrioFlow= "POSTIVE";
+		String  SceanrioFlow= "POSITIVE";
 
 		if (step.getParameters().isEmpty() || step.getParameters().size() < 1) {
 			logger.error("Parameter is  missing from DSL step");

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DemoAuthentication.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/DemoAuthentication.java
@@ -34,7 +34,7 @@ import io.mosip.testrig.dslrig.ivv.orchestrator.dslConfigManager;
 public class DemoAuthentication extends BaseTestCaseUtil implements StepInterface {
 	static Logger logger = Logger.getLogger(DemoAuthentication.class);
 	private static final String DEMOPATH = "idaData/DemoAuth/DemoAuth.yml";
-
+	private static final String DEMOPATHNEG = "idaData/DemoAuth/DemoAuthNeg.yml";
 	DemoAuth demoAuth = new DemoAuth();
 
 	static {
@@ -63,6 +63,7 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 		Object[] casesListVID = null;
 		Object[] casesListHandles = null;
 		String updateAgeFlag = null;
+		String  SceanrioFlow= "POSTIVE";
 
 		if (step.getParameters().isEmpty() || step.getParameters().size() < 1) {
 			logger.error("Parameter is  missing from DSL step");
@@ -107,7 +108,11 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 		if (step.getParameters().size() > 4)
 			updateAgeFlag = step.getParameters().get(4);
 		
-		if (step.getParameters().size() > 5) {
+		if (step.getParameters().size() == 5 && step.getParameters().get(4).equals("ERROR")) { // e2e_bioAuthentication(faceDevice,$$uin,$$personaFilePath)
+			SceanrioFlow = step.getParameters().get(4);
+		}
+		
+		if (step.getParameters().size() > 5 && !step.getParameters().get(4).equals("ERROR")) {
 			handleKey = step.getParameters().get(5);
 			_personFilePath = step.getParameters().get(2);
 			if (handleKey.startsWith("$$") && _personFilePath.startsWith("$$")) {
@@ -131,6 +136,11 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 		} else
 			handleList = new ArrayList<>(step.getScenario().getVidPersonaProp().stringPropertyNames());
 
+		String fileName = null;
+		if(SceanrioFlow.equalsIgnoreCase("ERROR"))
+			fileName = DEMOPATHNEG;
+		else
+			fileName = DEMOPATH;
 		for (String uin : uinList) {
 			String personFilePathvalue = null;
 
@@ -149,7 +159,7 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 			List<String> addressFetchList = new ArrayList<String>();
 			addressFetchList.add(E2EConstants.DEMOADDRESSFETCH);
 			addressResponse = packetUtility.retrieveBiometric(personFilePathvalue, addressFetchList, step);
-			Object[] testObj = demoAuth.getYmlTestData(DEMOPATH);
+			Object[] testObj = demoAuth.getYmlTestData(fileName);
 			TestCaseDTO test = (TestCaseDTO) testObj[0];
 			String input = test.getInput();
 			input = JsonPrecondtion.parseAndReturnJsonContent(input, uin, "individualId");
@@ -303,24 +313,24 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 			if (BaseTestCase.getSupportedIdTypesValueFromActuator().contains("UIN")
 					|| BaseTestCase.getSupportedIdTypesValueFromActuator().contains("uin")) {
 
-				casesListUIN = demoAuth.getYmlTestData(DEMOPATH);
+				casesListUIN = demoAuth.getYmlTestData(fileName);
 
 			}
 
 			else if (BaseTestCase.getSupportedIdTypesValueFromActuator().contains("VID")
 					|| BaseTestCase.getSupportedIdTypesValueFromActuator().contains("vid")) {
-				casesListVID = demoAuth.getYmlTestData(DEMOPATH);
+				casesListVID = demoAuth.getYmlTestData(fileName);
 			}
 
 			else {
-				casesListUIN = demoAuth.getYmlTestData(DEMOPATH);
-				casesListVID = demoAuth.getYmlTestData(DEMOPATH);
+				casesListUIN = demoAuth.getYmlTestData(fileName);
+				casesListVID = demoAuth.getYmlTestData(fileName);
 			}
 
 			// inputJson.put("identityRequest", identityReqJson.toString());
 
 			if (idType.contains("UIN") || idType.contains("uin")) {
-				casesListUIN = demoAuth.getYmlTestData(DEMOPATH);
+				casesListUIN = demoAuth.getYmlTestData(fileName);
 			}
 
 			if (casesListUIN != null) {
@@ -358,7 +368,7 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 			List<String> addressFetchList = new ArrayList<String>();
 			addressFetchList.add(E2EConstants.DEMOADDRESSFETCH);
 			addressResponse = packetUtility.retrieveBiometric(personFilePathvalue, addressFetchList, step);
-			Object[] testObj = demoAuth.getYmlTestData(DEMOPATH);
+			Object[] testObj = demoAuth.getYmlTestData(fileName);
 			TestCaseDTO test = (TestCaseDTO) testObj[0];
 			String input = test.getInput();
 			input = JsonPrecondtion.parseAndReturnJsonContent(input, vid, "individualId");
@@ -504,24 +514,24 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 			if (BaseTestCase.getSupportedIdTypesValueFromActuator().contains("UIN")
 					|| BaseTestCase.getSupportedIdTypesValueFromActuator().contains("uin")) {
 
-				casesListUIN = demoAuth.getYmlTestData(DEMOPATH);
+				casesListUIN = demoAuth.getYmlTestData(fileName);
 
 			}
 
 			else if (BaseTestCase.getSupportedIdTypesValueFromActuator().contains("VID")
 					|| BaseTestCase.getSupportedIdTypesValueFromActuator().contains("vid")) {
-				casesListVID = demoAuth.getYmlTestData(DEMOPATH);
+				casesListVID = demoAuth.getYmlTestData(fileName);
 			}
 
 			else {
-				casesListUIN = demoAuth.getYmlTestData(DEMOPATH);
-				casesListVID = demoAuth.getYmlTestData(DEMOPATH);
+				casesListUIN = demoAuth.getYmlTestData(fileName);
+				casesListVID = demoAuth.getYmlTestData(fileName);
 			}
 
 			// inputJson.put("identityRequest", identityReqJson.toString());
 
 			if (idType.contains("VID") || idType.contains("vid")) {
-				casesListVID = demoAuth.getYmlTestData(DEMOPATH);
+				casesListVID = demoAuth.getYmlTestData(fileName);
 			}
 
 			if (casesListVID != null) {
@@ -559,7 +569,7 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 			List<String> addressFetchList = new ArrayList<String>();
 			addressFetchList.add(E2EConstants.DEMOADDRESSFETCH);
 			addressResponse = packetUtility.retrieveBiometric(personFilePathvalue, addressFetchList, step);
-			Object[] testObj = demoAuth.getYmlTestData(DEMOPATH);
+			Object[] testObj = demoAuth.getYmlTestData(fileName);
 			TestCaseDTO test = (TestCaseDTO) testObj[0];
 			String input = test.getInput();
 			input = JsonPrecondtion.parseAndReturnJsonContent(input, handle, "individualId");
@@ -706,7 +716,7 @@ public class DemoAuthentication extends BaseTestCaseUtil implements StepInterfac
 
 			if (idType.stream()
 				    .anyMatch(s -> s != null && s.toLowerCase().contains("handle"))) {
-				casesListHandles = demoAuth.getYmlTestData(DEMOPATH);
+				casesListHandles = demoAuth.getYmlTestData(fileName);
 			}
 
 			if (casesListHandles != null) {

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -26759,7 +26759,7 @@
 	},
 	{
 		"Scenario": "226",
-		"Tag": "Positive_Test",
+		"Tag": "Negative_Test",
 		"Persona": "ResidentMaleAdult",
 		"Group": "NA",
 		"Description": "Resident walks into registration center completes the process  gets UIN card . Resident then updates name and gets updated UIN try to authenticate with old name",
@@ -26890,7 +26890,7 @@
 			"Action": "e2e_updateDemoOrBioDetails(0/*BIO_TYPE*/,0/*MISS_FIELDS*/,name=salman khan,$$personaFilePath)"
 		},
 		"Step-21": {
-			"Description": "Peforms demographic authentication",
+			"Description": "Performs demographic authentication",
 			"Input Parameters": "Demo graphic details, persona, UIN and VID",
 			"Return Value": "NA",
 			"Action": "e2e_demoAuthentication(name,$$uin2,$$personaFilePath,$$vid,ERROR)"

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -26758,6 +26758,151 @@
 		}
 	},
 	{
+		"Scenario": "226",
+		"Tag": "Positive_Test",
+		"Persona": "ResidentMaleAdult",
+		"Group": "NA",
+		"Description": "Resident walks into registration center completes the process  gets UIN card . Resident then updates name and gets updated UIN try to authenticate with old name",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Index. Other parameter details can be found in parameter in-line comments",
+			"Return Value": "Pre-requisite details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Environment and user details. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false/*GUARDIAN_FLAG*/,Male)"
+		},
+		"Step-5": {
+			"Description": "Updates Demo graphic details and biometric in the persona file",
+			"Input Parameters": "Data to update and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_updateDemoOrBioDetails(0/*BIO_TYPE*/,0/*MISS_FIELDS*/,name=salman khan,$$personaFilePath)"
+		},
+		"Step-6": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-7": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-8": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid)"
+		},
+		"Step-9": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin=e2e_getUINByRid($$rid)"
+		},
+		"Step-10": {
+			"Description": "Updates Demo graphic details and biometric in the persona file",
+			"Input Parameters": "Data to update and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_updateDemoOrBioDetails(0/*BIO_TYPE*/,0/*MISS_FIELDS*/,name,$$personaFilePath)"
+		},
+		"Step-11": {
+			"Description": "Updates persona with UIN",
+			"Input Parameters": "Persona file path and UIN",
+			"Return Value": "NA",
+			"Action": "e2e_updateResidentWithUIN($$personaFilePath,$$uin)"
+		},
+		"Step-12": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$newTemplate=e2e_getPacketTemplate(UPDATE/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-13": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid2=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$newTemplate)"
+		},
+		"Step-14": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid2)"
+		},
+		"Step-15": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin2=e2e_getUINByRid($$rid2)"
+		},
+		"Step-16": {
+			"Description": "Gets Email ID configured for the UIN",
+			"Input Parameters": "UIN",
+			"Return Value": "Email ID",
+			"Action": "$$email=e2e_getEmailByUIN($$uin2)"
+		},
+		"Step-17": {
+			"Description": "Waits for given period in seconds",
+			"Input Parameters": "Time period in seconds to wait",
+			"Return Value": "NA",
+			"Action": "e2e_wait(UIN_WAIT_TIME)"
+		},
+		"Step-18": {
+			"Description": "Generated VID for the given UIN",
+			"Input Parameters": "UIN and other can be found in parameters in-line commnets",
+			"Return Value": "VID",
+			"Action": "$$vid=e2e_generateVID(Perpetual,$$uin2,$$email)"
+		},
+		"Step-19": {
+			"Description": "Waits for given period in seconds",
+			"Input Parameters": "Time period in seconds to wait",
+			"Return Value": "NA",
+			"Action": "e2e_wait(90)"
+		},
+		"Step-20": {
+			"Description": "Updates Demo graphic details and biometric in the persona file",
+			"Input Parameters": "Data to update and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_updateDemoOrBioDetails(0/*BIO_TYPE*/,0/*MISS_FIELDS*/,name=salman khan,$$personaFilePath)"
+		},
+		"Step-21": {
+			"Description": "Peforms demographic authentication",
+			"Input Parameters": "Demo graphic details, persona, UIN and VID",
+			"Return Value": "NA",
+			"Action": "e2e_demoAuthentication(name,$$uin2,$$personaFilePath,$$vid,ERROR)"
+		},
+		"Step-22": {
+			"Description": "Deletes temporary data generated during packet creation including resident data packet templates and extra files to ensure a clean state for each E2E execution",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_DeletePacketData()"
+		}
+	},
+	{
 		"Scenario": "AFTER_SUITE",
 		"Tag": "Positive_Test",
 		"Persona": "ResidentMaleAdult",

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoAuth.yml
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoAuth.yml
@@ -8,7 +8,7 @@ DemoAuth:
       input: '{
 		"requestTime": "$TIMESTAMP$",
 		"individualId": "uinnumber",
-		"transactionId": "1234567890",
+		"transactionId": "$TRANSACTIONID$",
 	    "individualIdType": "UIN",
         "bio": false,
         "demo": true,

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoAuthNeg.yml
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoAuthNeg.yml
@@ -1,0 +1,23 @@
+DemoAuth:
+  auth_DemoAuth_Valid_neg_deg:
+      endPoint: /idauthentication/v1/auth/$partnerKeyURL$
+      role: ida
+      restMethod: post
+      inputTemplate: idaData/DemoAuth/demoAuth
+      outputTemplate: idaData/DemoAuth/demoAuthResult
+      input: '{
+		"requestTime": "$TIMESTAMP$",
+		"individualId": "uinnumber",
+		"transactionId": "1234567890",
+	    "individualIdType": "UIN",
+        "bio": false,
+        "demo": true,
+        "otp": false,
+		"identityRequest":{
+  "identityRequestTemplate": "idaData/DemoAuth/DemoIdentityEncrypt"
+	}
+	}'
+      output: '{
+  "authStatus": "false"
+}'
+  

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoAuthNeg.yml
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoAuthNeg.yml
@@ -8,7 +8,7 @@ DemoAuth:
       input: '{
 		"requestTime": "$TIMESTAMP$",
 		"individualId": "uinnumber",
-		"transactionId": "1234567890",
+		"transactionId": "$TRANSACTIONID$",
 	    "individualIdType": "UIN",
         "bio": false,
         "demo": true,

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoKYC.yml
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/DemoKYC.yml
@@ -8,7 +8,7 @@ EkycDemo:
       input: '{
 		"requestTime": "$TIMESTAMP$",
 		"individualId": "uinnumber",
-		"transactionId": "1234567890",
+		"transactionId": "$TRANSACTIONID$",
 	    "individualIdType": "UIN",
         "bio": false,
         "demo": true,

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/EkycDemo.yml
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/idaData/DemoAuth/EkycDemo.yml
@@ -7,7 +7,7 @@ DemoAuth:
       outputTemplate: idaData/DemoAuth/demoEkycResult
       input: '{
         "timestamp": "$TIMESTAMP$",
-        "transactionId": "1234567890"
+        "transactionId": "$TRANSACTIONID$"
     }'
       output: '{
   "authStatus": "true"


### PR DESCRIPTION
MOSIP-44398-DSL SCNARIO-Resident updates demographic details, authentication with old details should fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added negative-demo authentication flows and a new negative UIN update scenario to broaden end-to-end failure and edge-case coverage.
  * Updated multiple test flows to allow selecting normal vs. negative demo data paths for error-condition verification.
* **Chores**
  * Parameterized transaction identifiers across demo test inputs for more flexible, repeatable test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->