### PR TITLE
MOSIP-44400- New Scnario Resident walks into the registration center completes the process with empty email id failed gets the UIN card.

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
@@ -1077,10 +1077,13 @@ public class PacketUtility extends BaseTestCaseUtil {
 						updateAttribute.put(arr[0].trim(), langcode + "=" + arr[1].trim());
 					} else
 						updateAttribute.put(arr[0].trim(),
-								(arr[0].trim().equalsIgnoreCase("email")
-										? (arr[1].trim().equalsIgnoreCase("testmosip") ? "dslautomation@mosip.io"
-												: arr[1].trim() + "@mosip.io")
-										: arr[1].trim()));
+						        (arr[1].trim().equalsIgnoreCase("empty") ? ""
+						                : (arr[0].trim().equalsIgnoreCase("email")
+						                        ? (arr[1].trim().equalsIgnoreCase("testmosip")
+						                                ? "dslautomation@mosip.io"
+						                                : arr[1].trim() + "@mosip.io")
+						                        : arr[1].trim())));
+
 				}
 				// Pass phone and email as empty
 				else {

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -26982,6 +26982,79 @@
 		}
 	},
 	{
+		"Scenario": "228",
+		"Tag": "Positive_Test",
+		"Persona": "ResidentMaleAdult",
+		"Group": "NA",
+		"Description": "Resident walks into the registration center completes the process with empty email id failed gets the UIN card.",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Details can be found in in-line comments on the parameters",
+			"Return Value": "pre-requisite details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Environment and user details.Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false/*GUARDIAN_FLAG*/,Male)"
+		},
+		"Step-5": {
+			"Description": "Updates Demographic details and biometric in the persona file",
+			"Input Parameters": "Data to update and persona file path. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_updateDemoOrBioDetails(0/*BIO_TYPE*/,0/*MISS_FIELDS*/,email=empty,$$personaFilePath)"
+		},
+		"Step-6": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-7": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-8": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(REREGISTER/*PACKET_STATUS*/,$$rid)"
+		},
+		"Step-9": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$rid,VALIDATE_PACKET,FAILED)"
+		},
+		"Step-10": {
+			"Description": "Deletes temporary data generated during packet creation including resident data packet templates and extra files to ensure a clean state for each E2E execution",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_DeletePacketData()"
+		}
+	},
+	{
 		"Scenario": "AFTER_SUITE",
 		"Tag": "Positive_Test",
 		"Persona": "ResidentMaleAdult",

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -26983,7 +26983,7 @@
 	},
 	{
 		"Scenario": "228",
-		"Tag": "Positive_Test",
+		"Tag": "Negative_Test",
 		"Persona": "ResidentMaleAdult",
 		"Group": "NA",
 		"Description": "Resident walks into the registration center completes the process with empty email id failed gets the UIN card.",


### PR DESCRIPTION
Resident walks into the registration center completes the process with empty email id failed gets the UIN card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new scenario modeling a registration flow with an empty email, exercising packet creation, sync, validation failure, and cleanup.
* **Bug Fixes**
  * Improved test runner handling for empty-value placeholders and a special-case for large-document persona steps to ensure correct test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->