### PR TITLE
MOSIP-44822- Fixed get packet tag extra fingure device isuue

### DIFF
--- a/mosip-packet-creator/src/main/resources/dockersupport/centralized/mosip-packet-creator/profile_resource/templates_data/IDMetaInfo.json
+++ b/mosip-packet-creator/src/main/resources/dockersupport/centralized/mosip-packet-creator/profile_resource/templates_data/IDMetaInfo.json
@@ -180,20 +180,7 @@
   "proofOfIdentity" : "DOC004",
   "proofOfException" : "EOP",
   "registrationId" : "10003100240000420210219103615",
-  "capturedRegisteredDevices" : [ {
-    "deviceServiceVersion" : "0.9.5",
-    "digitalId" : {
-      "dateTime" : "2021-02-19T10:30:58.926Z",
-      "deviceSubType" : "Slap",
-      "model" : "SLAP01",
-      "type" : "Finger",
-      "make" : "MOSIP",
-      "serialNo" : "1234567890",
-      "deviceProviderId" : "MOSIP.PROXY.SBI",
-      "deviceProvider" : "MOSIP"
-    },
-    "deviceCode" : "b692b595-3523-slap-99fc-bd76e35f190f"
-  },
+  "capturedRegisteredDevices" : [ 
   {
     "deviceServiceVersion" : "0.9.5",
     "digitalId" : {


### PR DESCRIPTION
MOSIP-44822- Fixed get packet tag extra fingure device isuue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the device configuration template by removing a device entry from the captured registered devices list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->