### PR TITLE
MOSIP-32609- Added regclient version in DSL packet 

### DIFF
--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -1037,31 +1037,46 @@ public class PacketMakerService {
 
 		List<String> paths = new ArrayList<>();
 
-		Path trustedRoot = Paths.get(System.getProperty("user.dir"))
-				.toAbsolutePath()
-				.normalize();
+		// Normalize base directory
 		Path baseDir = Paths.get(packetRootFolder)
 				.toAbsolutePath()
 				.normalize();
-		if (!baseDir.startsWith(trustedRoot)) {
+
+		// ✅ Validate directory exists
+		if (!Files.exists(baseDir) || !Files.isDirectory(baseDir)) {
 			throw new SecurityException(
 					"Invalid packet root folder: " + baseDir);
 		}
+
 		File packetFolder = baseDir.toFile();
-		File[] biometricFiles = packetFolder.listFiles((d, name) -> name.endsWith(".xml"));
+
+		File[] biometricFiles = packetFolder.listFiles((d, name) -> name != null && name.endsWith(".xml"));
+
+		// ✅ Handle null safely
 		if (biometricFiles == null) {
 			return paths;
 		}
+
 		for (File file : biometricFiles) {
+
 			Path filePath = file.toPath()
 					.toAbsolutePath()
 					.normalize();
+
+			// ✅ Ensure file stays inside base directory
 			if (!filePath.startsWith(baseDir)) {
 				throw new SecurityException(
 						"Invalid file path detected: " + filePath);
 			}
+
+			// ✅ Ensure it's a regular file
+			if (!Files.isRegularFile(filePath)) {
+				continue;
+			}
+
 			paths.add(filePath.toString());
 		}
+
 		return paths;
 	}
 

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -1037,44 +1038,40 @@ public class PacketMakerService {
 
 		List<String> paths = new ArrayList<>();
 
-		// Normalize base directory
-		Path baseDir = Paths.get(packetRootFolder)
-				.toAbsolutePath()
-				.normalize();
+		try {
 
-		// ✅ Validate directory exists
-		if (!Files.exists(baseDir) || !Files.isDirectory(baseDir)) {
-			throw new SecurityException(
-					"Invalid packet root folder: " + baseDir);
-		}
+			File packetFolder = new File(packetRootFolder).getCanonicalFile();
 
-		File packetFolder = baseDir.toFile();
-
-		File[] biometricFiles = packetFolder.listFiles((d, name) -> name != null && name.endsWith(".xml"));
-
-		// ✅ Handle null safely
-		if (biometricFiles == null) {
-			return paths;
-		}
-
-		for (File file : biometricFiles) {
-
-			Path filePath = file.toPath()
-					.toAbsolutePath()
-					.normalize();
-
-			// ✅ Ensure file stays inside base directory
-			if (!filePath.startsWith(baseDir)) {
-				throw new SecurityException(
-						"Invalid file path detected: " + filePath);
+			// Validate directory
+			if (!packetFolder.exists() || !packetFolder.isDirectory()) {
+				return paths;
 			}
 
-			// ✅ Ensure it's a regular file
-			if (!Files.isRegularFile(filePath)) {
-				continue;
+			File[] biometricFiles = packetFolder.listFiles(
+					(dir, name) -> name != null && name.endsWith(".xml"));
+
+			if (biometricFiles == null) {
+				return paths;
 			}
 
-			paths.add(filePath.toString());
+			for (File file : biometricFiles) {
+
+				File canonicalFile = file.getCanonicalFile();
+
+				// Ensure file stays inside base directory
+				if (!canonicalFile.getPath()
+						.startsWith(packetFolder.getPath())) {
+
+					throw new SecurityException(
+							"Invalid file path: " + canonicalFile);
+				}
+
+				paths.add(canonicalFile.getAbsolutePath());
+			}
+
+		} catch (IOException e) {
+			throw new RuntimeException(
+					"Error reading biometric files", e);
 		}
 
 		return paths;

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -327,14 +327,9 @@ public class PacketMakerService {
 				} else {
 					originalFileName = originalFileName.replaceFirst("^[^_]*_", "");
 				}
-				Path baseDir = Paths.get(templateLocation, source, processArg, "rid_id")
-						.normalize();
 
-				Path target = baseDir.resolve(originalFileName).normalize();
-
-				if (!target.startsWith(baseDir)) {
-					throw new SecurityException("Invalid file path detected: " + originalFileName);
-				}
+				Path target = Paths.get(templateLocation + File.separator + source + File.separator +
+						processArg + File.separator + "rid_id", originalFileName);
 
 				try {
 					Files.copy(sourceprereg, target, StandardCopyOption.REPLACE_EXISTING);
@@ -511,9 +506,8 @@ public class PacketMakerService {
 
 	boolean createPacket(String containerRootFolder, String regId, String dataFilePath, String type, String preregId,
 			String contextKey) throws Exception {
-		Path packetRootFolder = resolvePacketRootFolder(
-				getPacketRoot(getProcessRoot(containerRootFolder, contextKey), regId, type), contextKey);
-		String templateFile = getIdJSONFileLocation(packetRootFolder.toString());
+		String packetRootFolder = getPacketRoot(getProcessRoot(containerRootFolder, contextKey), regId, type);
+		String templateFile = getIdJSONFileLocation(packetRootFolder);
 		String process = VariableManager.getVariableValue(contextKey, "process").toString();
 		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
 		String officerId = null;
@@ -582,30 +576,30 @@ public class PacketMakerService {
 				return false;
 			}
 
-			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "registrationId", regId, true);
+			updatePacketMetaInfo(packetRootFolder, METADATA, "registrationId", regId, true);
 			if (preregId != null && !preregId.equalsIgnoreCase("0")) // newly added
 
-				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "preRegistrationId", preregId, true);
+				updatePacketMetaInfo(packetRootFolder, METADATA, "preRegistrationId", preregId, true);
 
 			String invalidDateValue = VariableManager
 					.getVariableValue(contextKey, "invalidDateFlag")
 					.toString();
 
 			if (invalidDateValue.equals("invalidCreationDate")) {
-				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "creationDate", null, true);
+				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", null, true);
 			} else if (invalidDateValue.contains("CreationDate")) {
 				String offsetValue = invalidDateValue.split("=")[1];
 				String updatedDate = APIRequestUtil.getAdjustedUTCDate(offsetValue);
-				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "creationDate", updatedDate, true);
+				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", updatedDate, true);
 			} else {
-				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "creationDate",
-						APIRequestUtil.getUTCDateTime(null), true);
+				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", APIRequestUtil.getUTCDateTime(null),
+						true);
 			}
-			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "machineId", machineId, false);
-			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "centerId", centerId, false);
-			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "Registration Client Version Number",
+			updatePacketMetaInfo(packetRootFolder, METADATA, "machineId", machineId, false);
+			updatePacketMetaInfo(packetRootFolder, METADATA, "centerId", centerId, false);
+			updatePacketMetaInfo(packetRootFolder, METADATA, "Registration Client Version Number",
 					getRegistrationClientVersion(contextKey), false);
-			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "registrationType",
+			updatePacketMetaInfo(packetRootFolder, METADATA, "registrationType",
 					StringUtils.capitalize(process.toLowerCase()), false);
 
 			// ToRead Context file
@@ -623,7 +617,7 @@ public class PacketMakerService {
 
 			if (!VariableManager.getVariableValue(contextKey, "invalidOfficerIDFlag").toString()
 					.equals("invalidOfficerID")) {
-				updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "officerId", officerId, false);
+				updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "officerId", officerId, false);
 			}
 			supervisorId = p.getProperty(MOSIPTEST_REGCLIENT_SUPERVISORID);
 
@@ -631,7 +625,7 @@ public class PacketMakerService {
 					.equalsIgnoreCase("true"))
 				supervisorId = generateCaseConvertedString(supervisorId);
 
-			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "supervisorId", supervisorId, false);
+			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "supervisorId", supervisorId, false);
 
 			// officerP
 			officerP = p.getProperty(MOSIP_TEST_REGCLIENT_PASSWORD);
@@ -641,7 +635,7 @@ public class PacketMakerService {
 				officerP = "true"; // valid
 			else
 				officerP = FALSE; // null
-			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "officerPassword", officerP, false);
+			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "officerPassword", officerP, false);
 
 			// supervisorP
 			supervisorP = p.getProperty(MOSIP_TEST_REGCLIENT_supervisorP);
@@ -651,33 +645,33 @@ public class PacketMakerService {
 				supervisorP = "true"; // valid
 			else
 				supervisorP = FALSE; // null
-			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "supervisorPassword", supervisorP, false);
+			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "supervisorPassword", supervisorP, false);
 
 			// officerBiometricFileName
 			officerBiometricFileName = p.getProperty("mosip.test.regclient.officerBiometricFileName");
 			if (officerBiometricFileName != null && officerBiometricFileName.length() > 1) {
 			} else
 				officerBiometricFileName = null;
-			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "officerBiometricFileName",
-					officerBiometricFileName, false);
+			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "officerBiometricFileName", officerBiometricFileName,
+					false);
 
 			// supervisorBiometricFileName
 			supervisorBiometricFileName = p.getProperty("mosip.test.regclient.supervisorBiometricFileName");
 			if (supervisorBiometricFileName != null && supervisorBiometricFileName.length() > 1) {
 			} else
 				supervisorBiometricFileName = null;
-			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "supervisorBiometricFileName",
+			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "supervisorBiometricFileName",
 					supervisorBiometricFileName, false);
 
-			updateAudit(packetRootFolder.toString(), regId, contextKey);
+			updateAudit(packetRootFolder, regId, contextKey);
 
 			LinkedList<String> sequence = updateHashSequence1(packetRootFolder);
 			LinkedList<String> operations_seq = updateHashSequence2(packetRootFolder);
 			if (preregId != null && preregId.equals("01")) // to generte invalid hash data
 			{
-				CommonUtil.write(packetRootFolder.resolve(PACKET_DATA_HASH_FILENAME),
+				CommonUtil.write(Path.of(packetRootFolder, PACKET_DATA_HASH_FILENAME),
 						"PACKET_DATA_HASH_INVALID_DATA".getBytes());
-				CommonUtil.write(packetRootFolder.resolve(PACKET_OPERATION_HASH_FILENAME),
+				CommonUtil.write(Path.of(packetRootFolder, PACKET_OPERATION_HASH_FILENAME),
 						"PACKET_OPERATION_HASH_INVALID_DATA".getBytes());
 			} else {
 				updatePacketDataHash(packetRootFolder, sequence, PACKET_DATA_HASH_FILENAME, contextKey);
@@ -707,21 +701,14 @@ public class PacketMakerService {
 		}
 		String encryptedHashFlag = VariableManager.getVariableValue(contextKey, "invalidEncryptedHashFlag").toString();
 		String encryptedHash = null;
-		Path baseDir = Paths.get(containerRootFolder).normalize();
-		Path zipPath = Paths.get(containerRootFolder + ".zip")
-				.normalize();
-		if (!zipPath.startsWith(baseDir.getParent())) {
-			throw new SecurityException(
-					"Invalid zip path detected: " + zipPath);
-		}
-		if (encryptedHashFlag.equalsIgnoreCase("invalidEncryptedHash")
-				&& type.equals("id")) {
+
+		// Make encrypted hash as invalid if "invalidEncryptedHashFlag --yes"
+		if (encryptedHashFlag.equalsIgnoreCase("invalidEncryptedHash") && type.equals("id"))
 			encryptedHash = "INVALID_ENCRYPTED_HASH";
-		} else {
-			byte[] fileBytes = Files.readAllBytes(zipPath);
+		else
 			encryptedHash = CryptoUtil.encodeToURLSafeBase64(
-					HMACUtils2.generateHash(fileBytes));
-		}
+					HMACUtils2.generateHash(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + ".zip"))));
+
 		String signaturevalue = VariableManager.getVariableValue(contextKey, "signature").toString();
 		String signature = "";
 		if (signaturevalue.equalsIgnoreCase("invalidSignature")) {
@@ -980,9 +967,9 @@ public class PacketMakerService {
 		return centerId + machineId + counter + currUTCTime;
 	}
 
-	private LinkedList<String> updateHashSequence1(Path packetRootFolder) throws Exception {
+	private LinkedList<String> updateHashSequence1(String packetRootFolder) throws Exception {
 		LinkedList<String> sequence = new LinkedList<>();
-		Path metaInfoPath = packetRootFolder.resolve(PACKET_META_FILENAME);
+		Path metaInfoPath = Path.of(packetRootFolder, PACKET_META_FILENAME);
 		JSONObject metaInfo;
 		try (BufferedReader reader = Files.newBufferedReader(metaInfoPath, StandardCharsets.UTF_8)) {
 			metaInfo = new JSONObject(reader.lines().collect(Collectors.joining()));
@@ -999,9 +986,9 @@ public class PacketMakerService {
 		return sequence;
 	}
 
-	private LinkedList<String> updateHashSequence2(Path packetRootFolder) throws Exception {
+	private LinkedList<String> updateHashSequence2(String packetRootFolder) throws Exception {
 		LinkedList<String> sequence = new LinkedList<>();
-		Path metaInfoPath = packetRootFolder.resolve(PACKET_META_FILENAME);
+		Path metaInfoPath = Path.of(packetRootFolder, PACKET_META_FILENAME);
 		JSONObject metaInfo;
 		try (BufferedReader reader = Files.newBufferedReader(metaInfoPath, StandardCharsets.UTF_8)) {
 			metaInfo = new JSONObject(reader.lines().collect(Collectors.joining()));
@@ -1016,7 +1003,7 @@ public class PacketMakerService {
 		return sequence;
 	}
 
-	private void updatePacketDataHash(Path packetRootFolder, LinkedList<String> sequence, String fileName,
+	private void updatePacketDataHash(String packetRootFolder, LinkedList<String> sequence, String fileName,
 			String contextKey) throws Exception {
 		MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -1032,83 +1019,36 @@ public class PacketMakerService {
 			logger.info("sequence packetDataHash >> {} ", packetDataHash);
 			logger.info("sequence packetDataHash2 >> {} ", packetDataHash2);
 		}
-		CommonUtil.write(packetRootFolder.resolve(fileName), packetDataHash2.getBytes());
+		CommonUtil.write(Path.of(packetRootFolder, fileName), packetDataHash2.getBytes());
 	}
 
-	private Path resolvePacketRootFolder(String packetRootFolder, String contextKey) throws IOException {
-		Path allowedBaseDirectory = resolvePacketBaseDirectory(contextKey);
-		Path normalizedPacketFolder = Paths.get(packetRootFolder)
-				.toAbsolutePath()
-				.normalize();
-
-		if (!normalizedPacketFolder.startsWith(allowedBaseDirectory)) {
-			throw new SecurityException("Invalid packet folder path: " + normalizedPacketFolder);
-		}
-
-		if (!Files.isDirectory(normalizedPacketFolder)) {
-			throw new SecurityException("Packet folder does not exist: " + normalizedPacketFolder);
-		}
-
-		Path canonicalPacketFolder = normalizedPacketFolder.toRealPath();
-		if (!canonicalPacketFolder.startsWith(allowedBaseDirectory)) {
-			throw new SecurityException("Invalid packet folder path: " + canonicalPacketFolder);
-		}
-
-		return canonicalPacketFolder;
+	private List<String> getBiometricFiles(String packetRootFolder) {
+		List<String> paths = new ArrayList<>();
+		File packetFolder = Path.of(packetRootFolder).toFile();
+		File[] biometricFiles = packetFolder.listFiles((d, name) -> name.endsWith(".xml"));
+		for (File file : biometricFiles) {
+			paths.add(file.getAbsolutePath());
 	}
-
-	private Path resolvePacketBaseDirectory(String contextKey) {
-		if (contextKey != null) {
-			Object configuredPacketPath = VariableManager.getVariableValue(contextKey, PACKETPATH);
-			if (configuredPacketPath != null && StringUtils.hasText(configuredPacketPath.toString())) {
-				return Paths.get(configuredPacketPath.toString()).toAbsolutePath().normalize();
-			}
-		}
-		return Paths.get(workDirectory).toAbsolutePath().normalize();
-	}
-
-	private List<String> getBiometricFiles(Path packetRootFolder) {
-		return getPacketFiles(packetRootFolder, path -> path.getFileName().toString().endsWith(".xml"));
+		return paths;
 	}
 
 	private List<String> getDemographicDocFiles(String packetRootFolder) {
-		return getPacketFiles(Paths.get(packetRootFolder).toAbsolutePath().normalize(),
-				path -> {
-					String fileName = path.getFileName().toString();
-					return fileName.endsWith(".pdf") || fileName.endsWith(".jpg") || fileName.equals("ID.json");
-				});
-	}
-
-	private List<String> getDemographicDocFiles(Path packetRootFolder) {
-		return getPacketFiles(packetRootFolder,
-				path -> {
-					String fileName = path.getFileName().toString();
-					return fileName.endsWith(".pdf") || fileName.endsWith(".jpg") || fileName.equals("ID.json");
-				});
-	}
-
-	private List<String> getOperationsFiles(Path packetRootFolder) {
-		return getPacketFiles(packetRootFolder, path -> path.getFileName().toString().equals("audit.json"));
-	}
-
-	private List<String> getPacketFiles(Path packetRootFolder, DirectoryStream.Filter<Path> filter) {
 		List<String> paths = new ArrayList<>();
-		if (!Files.isDirectory(packetRootFolder)) {
-			return paths;
+		File packetFolder = Path.of(packetRootFolder).toFile();
+		File[] documents = packetFolder
+				.listFiles((d, name) -> name.endsWith(".pdf") || name.endsWith(".jpg") || name.equals("ID.json"));
+		for (File file : documents) {
+			paths.add(file.getAbsolutePath());
 		}
+		return paths;
+	}
 
-		try (DirectoryStream<Path> files = Files.newDirectoryStream(packetRootFolder, filter)) {
-			for (Path file : files) {
-				Path canonicalFile = file.toRealPath();
-				if (!canonicalFile.startsWith(packetRootFolder)) {
-					throw new SecurityException("Invalid file path: " + canonicalFile);
-				}
-				if (Files.isRegularFile(canonicalFile)) {
-					paths.add(canonicalFile.toString());
-				}
-			}
-		} catch (IOException e) {
-			throw new RuntimeException("Error reading packet files", e);
+	private List<String> getOperationsFiles(String packetRootFolder) {
+		List<String> paths = new ArrayList<>();
+		File packetFolder = Path.of(packetRootFolder).toFile();
+		File[] documents = packetFolder.listFiles((d, name) -> name.equals("audit.json"));
+		for (File file : documents) {
+			paths.add(file.getAbsolutePath());
 		}
 		return paths;
 	}

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -216,24 +215,21 @@ public class PacketMakerService {
 		RestClient.logInfo(contextKey, "packPacketContainer:src=" + src + ",process=" + process + "PacketRoot="
 				+ tempPacketRootFolder + " regid=" + regId);
 		try {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, "id"), regId, "id",
-					contextKey);
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, "id"), regId, "id", contextKey);
 		} catch (Throwable e) {
 			logger.error(" ID Packet FAIL to Pack", e);
 
 		}
 
 		try {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, EVIDENCE), regId,
-					EVIDENCE,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, EVIDENCE), regId, EVIDENCE,
 					contextKey);
 		} catch (Throwable e) {
 			logger.error(" EVIDENCE Packet FAIL to Pack", e);
 
 		}
 		try {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, OPTIONAL), regId,
-					OPTIONAL,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, OPTIONAL), regId, OPTIONAL,
 					contextKey);
 		} catch (Throwable e) {
 			logger.error(" OPTIONAL Packet FAIL to Pack", e);
@@ -281,10 +277,8 @@ public class PacketMakerService {
 	/*
 	 * Create packet with our without Encryption
 	 */
-	public synchronized String createContainer(String dataFile, String templatePacketLocation, String source,
-			String processArg,
-			String preregId, String contextKey, boolean bZip, String additionalInfoReqId, File preRegPacketLocation)
-			throws Exception {
+	public synchronized String createContainer(String dataFile, String templatePacketLocation, String source, String processArg,
+			String preregId, String contextKey, boolean bZip, String additionalInfoReqId , File preRegPacketLocation) throws Exception {
 		String process = null;
 		String packetPath = "";
 		if (contextKey != null && !contextKey.equals("")) {
@@ -317,44 +311,41 @@ public class PacketMakerService {
 				process = tprocess;
 		}
 		if (preRegPacketLocation != null) {
-			List<String> files = getDemographicDocFiles(preRegPacketLocation.getAbsolutePath());
+		    List<String> files = getDemographicDocFiles(preRegPacketLocation.getAbsolutePath());
 
-			for (String filePath : files) {
-				Path sourceprereg = Paths.get(filePath);
-				String originalFileName = sourceprereg.getFileName().toString();
-				if (!originalFileName.toLowerCase().endsWith(".pdf")) {
-					continue;
-				} else {
-					originalFileName = originalFileName.replaceFirst("^[^_]*_", "");
-				}
+		    for (String filePath : files) {
+		        Path sourceprereg = Paths.get(filePath);
+		        String originalFileName = sourceprereg.getFileName().toString();
+		        if (!originalFileName.toLowerCase().endsWith(".pdf")) {
+		            continue;
+		        }else {
+		        	originalFileName = originalFileName.replaceFirst("^[^_]*_", "");
+		        }
 
-				Path target = Paths.get(templateLocation + File.separator + source + File.separator +
-						processArg + File.separator + "rid_id", originalFileName);
+		        Path target = Paths.get(templateLocation + File.separator + source + File.separator +
+		            processArg + File.separator + "rid_id", originalFileName);
 
-				try {
-					Files.copy(sourceprereg, target, StandardCopyOption.REPLACE_EXISTING);
-				} catch (IOException e) {
-					e.printStackTrace(); // Replace with proper logging
-				}
-			}
+		        try {
+		            Files.copy(sourceprereg, target, StandardCopyOption.REPLACE_EXISTING);
+		        } catch (IOException e) {
+		            e.printStackTrace(); // or log the error appropriately
+		        }
+		    }
 		}
 
-		String tempPacketRootFolder = createTempTemplate(templateLocation, appId, contextKey);
-
+		String tempPacketRootFolder = createTempTemplate(templateLocation, appId ,contextKey);
+		
 		// update document file here
 		createPacket(tempPacketRootFolder, regId, dataFile, "id", preregId, contextKey);
 		if (bZip)
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, "id"), regId, "id",
-					contextKey);
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, "id"), regId, "id", contextKey);
 		createPacket(tempPacketRootFolder, regId, dataFile, EVIDENCE, preregId, contextKey);
 		if (bZip)
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, EVIDENCE), regId,
-					EVIDENCE,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder ,contextKey), regId, EVIDENCE), regId, EVIDENCE,
 					contextKey);
 		createPacket(tempPacketRootFolder, regId, dataFile, OPTIONAL, preregId, contextKey);
 		if (bZip) {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, OPTIONAL), regId,
-					OPTIONAL,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, OPTIONAL), regId, OPTIONAL,
 					contextKey);
 			packContainer(tempPacketRootFolder, contextKey);
 
@@ -506,29 +497,29 @@ public class PacketMakerService {
 
 	boolean createPacket(String containerRootFolder, String regId, String dataFilePath, String type, String preregId,
 			String contextKey) throws Exception {
-		String packetRootFolder = getPacketRoot(getProcessRoot(containerRootFolder, contextKey), regId, type);
+		String packetRootFolder = getPacketRoot(getProcessRoot(containerRootFolder , contextKey), regId, type);
 		String templateFile = getIdJSONFileLocation(packetRootFolder);
-		String process = VariableManager.getVariableValue(contextKey, "process").toString();
+		String process=VariableManager.getVariableValue(contextKey, "process").toString();
 		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
 		String officerId = null;
 		String supervisorId = null;
 		String officerP;
 		String supervisorP;
-		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
+		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
 
 		String dataToMerge = null;
 		if (dataFilePath != null)
 			dataToMerge = Files.readString(Path.of(dataFilePath));
-		JSONObject jb = null;
-		jb = new JSONObject(dataToMerge).getJSONObject(IDENTITY);
+		JSONObject jb=null;
+			jb = new JSONObject(dataToMerge).getJSONObject(IDENTITY);
 		// workaround for MOSIP-18123
 
 		JSONObject jb1 = new JSONObject(dataToMerge);
 		List<String> jsonList = jb.keySet().stream().filter(j -> j.startsWith("proof")).collect(Collectors.toList());
 		jsonList.forEach(o -> {
-			jb1.getJSONObject(IDENTITY).getJSONObject(o).put(VALUE, o);
+				jb1.getJSONObject(IDENTITY).getJSONObject(o).put(VALUE, o);
 
-			jb1.getJSONObject(IDENTITY).getJSONObject(o).remove("refNumber");
+				jb1.getJSONObject(IDENTITY).getJSONObject(o).remove("refNumber");
 		});
 
 		dataToMerge = jb1.toString();
@@ -562,7 +553,7 @@ public class PacketMakerService {
 						VariableManager.getVariableValue(contextKey, MOUNTPATH).toString()
 								+ VariableManager.getVariableValue(contextKey, MOSIP_TEST_TEMP).toString(),
 						contextKey.replace(CONTEXT, ""), regId + "_invalidIds.json");
-				// To Do check Files.createDirectories(path.getParent());
+//To Do check				Files.createDirectories(path.getParent());
 				try {
 					Files.createFile(path);
 				} catch (FileAlreadyExistsException e) {
@@ -582,8 +573,8 @@ public class PacketMakerService {
 				updatePacketMetaInfo(packetRootFolder, METADATA, "preRegistrationId", preregId, true);
 
 			String invalidDateValue = VariableManager
-					.getVariableValue(contextKey, "invalidDateFlag")
-					.toString();
+			        .getVariableValue(contextKey, "invalidDateFlag")
+			        .toString();
 
 			if (invalidDateValue.equals("invalidCreationDate")) {
 				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", null, true);
@@ -597,11 +588,10 @@ public class PacketMakerService {
 			}
 			updatePacketMetaInfo(packetRootFolder, METADATA, "machineId", machineId, false);
 			updatePacketMetaInfo(packetRootFolder, METADATA, "centerId", centerId, false);
-			updatePacketMetaInfo(packetRootFolder, METADATA, "Registration Client Version Number",
-					getRegistrationClientVersion(contextKey), false);
 			updatePacketMetaInfo(packetRootFolder, METADATA, "registrationType",
 					StringUtils.capitalize(process.toLowerCase()), false);
-
+            updatePacketMetaInfo(packetRootFolder, METADATA, "Registration Client Version Number",
+					getRegistrationClientVersion(contextKey), false);
 			// ToRead Context file
 			String filePath = personaConfigPath + "/server.context." + contextKey + ".properties";
 			Properties p = new Properties();
@@ -688,8 +678,8 @@ public class PacketMakerService {
 		VariableManager.setVariableValue(contextKey, "META_INFO-META_DATA-centerId", centerId != null ? centerId : "");
 		CommonUtil.deleteOldTempDir(
 				VariableManager.getVariableValue(contextKey, MOUNTPATH).toString()
-						+ VariableManager.getVariableValue(contextKey, MOSIP_TEST_TEMP).toString() + "/" +
-						contextKey.replace(CONTEXT, "") + "/" + regId + "_schema.json");
+				+ VariableManager.getVariableValue(contextKey, MOSIP_TEST_TEMP).toString()+"/"+
+		contextKey.replace(CONTEXT, "")+"/"+ regId + "_schema.json");
 		return true;
 	}
 
@@ -706,12 +696,11 @@ public class PacketMakerService {
 		if (encryptedHashFlag.equalsIgnoreCase("invalidEncryptedHash") && type.equals("id"))
 			encryptedHash = "INVALID_ENCRYPTED_HASH";
 		else
-			encryptedHash = CryptoUtil.encodeToURLSafeBase64(
-					HMACUtils2.generateHash(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + ".zip"))));
-
+			encryptedHash = CryptoUtil.encodeToURLSafeBase64(HMACUtils2.generateHash(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + ".zip"))));
+		
 		String signaturevalue = VariableManager.getVariableValue(contextKey, "signature").toString();
-		String signature = "";
-		if (signaturevalue.equalsIgnoreCase("invalidSignature")) {
+		String signature="";
+		if(signaturevalue.equalsIgnoreCase("invalidSignature")){
 			String newKey = contextKey.replaceAll("(?<=_S)\\d+(?=_context)", "0");
 			signature = Base64.getUrlEncoder().withoutPadding().encodeToString(
 					cryptoUtil.sign(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + UNENCZIP)), newKey));
@@ -736,7 +725,7 @@ public class PacketMakerService {
 		}
 
 		String containerMetaDataFileLocation = containerRootFolder + JSON;
-		return fixContainerMetaData(containerMetaDataFileLocation, regId, type, encryptedHash, signature, contextKey);
+		return fixContainerMetaData(containerMetaDataFileLocation, regId, type, encryptedHash, signature , contextKey);
 	}
 
 	boolean packContainer(String containerRootFolder, String contextKey) throws Exception {
@@ -776,9 +765,9 @@ public class PacketMakerService {
 
 	public synchronized boolean zipAndEncrypt(Path zipSrcFolder, String contextKey) throws Exception {
 		Path finalZipFile = Path.of(zipSrcFolder + UNENCZIP);
-		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
-		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
-
+		String centerId= VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
+		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
+				
 		// Use buffered streams
 		try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(
 				new FileOutputStream(finalZipFile.toFile()))) {
@@ -835,9 +824,8 @@ public class PacketMakerService {
 		return new File(packetRootFolder + File.separator + "ID".toUpperCase() + JSON).toString();
 	}
 
-	private String getProcessRoot(String containerRootFolder, String contextKey) {
-		return Path.of(containerRootFolder, src, VariableManager.getVariableValue(contextKey, "process").toString())
-				.toString();
+	private String getProcessRoot(String containerRootFolder , String contextKey) {
+		return Path.of(containerRootFolder, src, VariableManager.getVariableValue(contextKey, "process").toString()).toString();
 	}
 
 	private String getPacketRoot(String processRootFolder, String rid, String type) {
@@ -848,11 +836,10 @@ public class PacketMakerService {
 		return Path.of(processRootFolder, rid + UNDERSCORE + type.toLowerCase() + JSON).toString();
 	}
 
-	private String createTempTemplate(String templatePacket, String rid, String contextKey)
-			throws IOException, SecurityException {
+	private String createTempTemplate(String templatePacket, String rid, String contextKey) throws IOException, SecurityException {
 		Path sourceDirectory = Paths.get(templatePacket);
-		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
-		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
+		String centerId= VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
+		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
 		String tempDir = null;
 		if (VariableManager.getVariableValue(contextKey, PACKETPATH).toString().equals(""))
 			tempDir = workDirectory + File.separator + rid + "-" + centerId + "_" + machineId + "-"
@@ -862,13 +849,12 @@ public class PacketMakerService {
 					+ centerId + "_" + machineId + "-" + getcurrentTimeStamp();
 		Path targetDirectory = Paths.get(tempDir);
 		FileSystemUtils.copyRecursively(sourceDirectory, targetDirectory);
-		setupTemplateName(tempDir, rid, contextKey);
+		setupTemplateName(tempDir, rid , contextKey);
 		return targetDirectory.toString();
 	}
 
-	private void setupTemplateName(String templateRootPath, String regId, String contextKey) throws SecurityException {
-		String finalPath = templateRootPath + File.separator + src + File.separator
-				+ VariableManager.getVariableValue(contextKey, "process").toString();
+	private void setupTemplateName(String templateRootPath, String regId , String contextKey) throws SecurityException {
+		String finalPath = templateRootPath + File.separator + src + File.separator + VariableManager.getVariableValue(contextKey, "process").toString();
 		File rootFolder = new File(finalPath);
 		File[] listFiles = rootFolder.listFiles();
 		boolean assignValue = false;
@@ -889,8 +875,8 @@ public class PacketMakerService {
 	}
 
 	private boolean fixContainerMetaData(String fileToFix, String rid, String type, String encryptedHash,
-			String signature, String contextKey) throws IOException, Exception {
-		String process = VariableManager.getVariableValue(contextKey, "process").toString();
+			String signature , String contextKey) throws IOException, Exception {
+		String process =VariableManager.getVariableValue(contextKey, "process").toString();
 		Map<String, String> metaData = new HashMap();
 		metaData.put("process", process);
 		metaData.put("creationdate", APIRequestUtil.getUTCDateTime(null));
@@ -958,8 +944,8 @@ public class PacketMakerService {
 	}
 
 	private String generateRegId(String contextKey) {
-		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
-		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
+		String centerId= VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
+		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
 		SimpleDateFormat f = new SimpleDateFormat("yyyyMMddHHmmss");
 		f.setTimeZone(TimeZone.getTimeZone("UTC"));
 		String currUTCTime = f.format(new Date());
@@ -1028,7 +1014,7 @@ public class PacketMakerService {
 		File[] biometricFiles = packetFolder.listFiles((d, name) -> name.endsWith(".xml"));
 		for (File file : biometricFiles) {
 			paths.add(file.getAbsolutePath());
-	}
+		}
 		return paths;
 	}
 
@@ -1068,7 +1054,8 @@ public class PacketMakerService {
 	 * 
 	 * return sequence; }
 	 */
-
+	
+	
 	private LinkedList<String> updateHashSequence(JSONObject metaInfo, String parentKey, String seqName,
 			LinkedList<String> sequence, List<String> files) {
 		// Early exit if the files list is empty or null
@@ -1122,33 +1109,33 @@ public class PacketMakerService {
 	 * CommonUtil.write(Path.of(packetRootFolder, PACKET_META_FILENAME),
 	 * jsonObject.toString().getBytes(UTF8)); }
 	 */
-
+	
 	private void updatePacketMetaInfo(String packetRootFolder, String parentKey, String key, String value,
 			boolean parentLevel) throws Exception {
-		String metaInfo_json = Files.readString(Path.of(packetRootFolder, PACKET_META_FILENAME));
-		JSONObject jsonObject = new JSONObject(metaInfo_json);
-		JSONObject identityObj = jsonObject.getJSONObject(IDENTITY);
-		if (parentLevel)
-			identityObj.put(key, value);
-		boolean updated = false;
-		if (identityObj.has(parentKey)) {
-			JSONArray metadata = identityObj.getJSONArray(parentKey);
-			for (int i = 0; i < metadata.length(); i++) {
-				JSONObject metaItem = metadata.getJSONObject(i);
-				if (metaItem.getString(LABEL).equals(key)) {
-					metaItem.put(VALUE, value);
-					updated = true;
+			String metaInfo_json = Files.readString(Path.of(packetRootFolder, PACKET_META_FILENAME));
+			JSONObject jsonObject = new JSONObject(metaInfo_json);
+			JSONObject identityObj = jsonObject.getJSONObject(IDENTITY);
+			if (parentLevel)
+				identityObj.put(key, value);
+			boolean updated = false;
+			if (identityObj.has(parentKey)) {
+				JSONArray metadata = identityObj.getJSONArray(parentKey);
+				for (int i = 0; i < metadata.length(); i++) {
+					JSONObject metaItem = metadata.getJSONObject(i);
+					if (metaItem.getString(LABEL).equals(key)) {
+						metaItem.put(VALUE, value);
+						updated = true;
+					}
 				}
 			}
+			if (!updated) {
+				JSONObject rid = new JSONObject();
+				rid.put(LABEL, key);
+				rid.put(VALUE, value);
+				jsonObject.getJSONObject(IDENTITY).getJSONArray(parentKey).put(rid);
+			}
+			CommonUtil.write(Path.of(packetRootFolder, PACKET_META_FILENAME), jsonObject.toString().getBytes(UTF8));
 		}
-		if (!updated) {
-			JSONObject rid = new JSONObject();
-			rid.put(LABEL, key);
-			rid.put(VALUE, value);
-			jsonObject.getJSONObject(IDENTITY).getJSONArray(parentKey).put(rid);
-		}
-		CommonUtil.write(Path.of(packetRootFolder, PACKET_META_FILENAME), jsonObject.toString().getBytes(UTF8));
-	}
 
 	private String generateCaseConvertedString(String inputString) {
 		StringBuilder result = new StringBuilder();

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -1034,10 +1034,19 @@ public class PacketMakerService {
 	}
 
 	private List<String> getBiometricFiles(String packetRootFolder) {
+
 		List<String> paths = new ArrayList<>();
+
+		Path trustedRoot = Paths.get(System.getProperty("user.dir"))
+				.toAbsolutePath()
+				.normalize();
 		Path baseDir = Paths.get(packetRootFolder)
 				.toAbsolutePath()
 				.normalize();
+		if (!baseDir.startsWith(trustedRoot)) {
+			throw new SecurityException(
+					"Invalid packet root folder: " + baseDir);
+		}
 		File packetFolder = baseDir.toFile();
 		File[] biometricFiles = packetFolder.listFiles((d, name) -> name.endsWith(".xml"));
 		if (biometricFiles == null) {

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -4,6 +4,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
 import javax.xml.bind.DatatypeConverter;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -50,6 +52,8 @@ import org.springframework.security.crypto.codec.Hex;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -211,21 +215,24 @@ public class PacketMakerService {
 		RestClient.logInfo(contextKey, "packPacketContainer:src=" + src + ",process=" + process + "PacketRoot="
 				+ tempPacketRootFolder + " regid=" + regId);
 		try {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, "id"), regId, "id", contextKey);
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, "id"), regId, "id",
+					contextKey);
 		} catch (Throwable e) {
 			logger.error(" ID Packet FAIL to Pack", e);
 
 		}
 
 		try {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, EVIDENCE), regId, EVIDENCE,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, EVIDENCE), regId,
+					EVIDENCE,
 					contextKey);
 		} catch (Throwable e) {
 			logger.error(" EVIDENCE Packet FAIL to Pack", e);
 
 		}
 		try {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, OPTIONAL), regId, OPTIONAL,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, OPTIONAL), regId,
+					OPTIONAL,
 					contextKey);
 		} catch (Throwable e) {
 			logger.error(" OPTIONAL Packet FAIL to Pack", e);
@@ -273,8 +280,10 @@ public class PacketMakerService {
 	/*
 	 * Create packet with our without Encryption
 	 */
-	public synchronized String createContainer(String dataFile, String templatePacketLocation, String source, String processArg,
-			String preregId, String contextKey, boolean bZip, String additionalInfoReqId , File preRegPacketLocation) throws Exception {
+	public synchronized String createContainer(String dataFile, String templatePacketLocation, String source,
+			String processArg,
+			String preregId, String contextKey, boolean bZip, String additionalInfoReqId, File preRegPacketLocation)
+			throws Exception {
 		String process = null;
 		String packetPath = "";
 		if (contextKey != null && !contextKey.equals("")) {
@@ -307,41 +316,44 @@ public class PacketMakerService {
 				process = tprocess;
 		}
 		if (preRegPacketLocation != null) {
-		    List<String> files = getDemographicDocFiles(preRegPacketLocation.getAbsolutePath());
+			List<String> files = getDemographicDocFiles(preRegPacketLocation.getAbsolutePath());
 
-		    for (String filePath : files) {
-		        Path sourceprereg = Paths.get(filePath);
-		        String originalFileName = sourceprereg.getFileName().toString();
-		        if (!originalFileName.toLowerCase().endsWith(".pdf")) {
-		            continue;
-		        }else {
-		        	originalFileName = originalFileName.replaceFirst("^[^_]*_", "");
-		        }
+			for (String filePath : files) {
+				Path sourceprereg = Paths.get(filePath);
+				String originalFileName = sourceprereg.getFileName().toString();
+				if (!originalFileName.toLowerCase().endsWith(".pdf")) {
+					continue;
+				} else {
+					originalFileName = originalFileName.replaceFirst("^[^_]*_", "");
+				}
 
-		        Path target = Paths.get(templateLocation + File.separator + source + File.separator +
-		            processArg + File.separator + "rid_id", originalFileName);
+				Path target = Paths.get(templateLocation + File.separator + source + File.separator +
+						processArg + File.separator + "rid_id", originalFileName);
 
-		        try {
-		            Files.copy(sourceprereg, target, StandardCopyOption.REPLACE_EXISTING);
-		        } catch (IOException e) {
-		            e.printStackTrace(); // or log the error appropriately
-		        }
-		    }
+				try {
+					Files.copy(sourceprereg, target, StandardCopyOption.REPLACE_EXISTING);
+				} catch (IOException e) {
+					e.printStackTrace(); // or log the error appropriately
+				}
+			}
 		}
 
-		String tempPacketRootFolder = createTempTemplate(templateLocation, appId ,contextKey);
-		
+		String tempPacketRootFolder = createTempTemplate(templateLocation, appId, contextKey);
+
 		// update document file here
 		createPacket(tempPacketRootFolder, regId, dataFile, "id", preregId, contextKey);
 		if (bZip)
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, "id"), regId, "id", contextKey);
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, "id"), regId, "id",
+					contextKey);
 		createPacket(tempPacketRootFolder, regId, dataFile, EVIDENCE, preregId, contextKey);
 		if (bZip)
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder ,contextKey), regId, EVIDENCE), regId, EVIDENCE,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, EVIDENCE), regId,
+					EVIDENCE,
 					contextKey);
 		createPacket(tempPacketRootFolder, regId, dataFile, OPTIONAL, preregId, contextKey);
 		if (bZip) {
-			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder , contextKey), regId, OPTIONAL), regId, OPTIONAL,
+			packPacket(getPacketRoot(getProcessRoot(tempPacketRootFolder, contextKey), regId, OPTIONAL), regId,
+					OPTIONAL,
 					contextKey);
 			packContainer(tempPacketRootFolder, contextKey);
 
@@ -493,29 +505,29 @@ public class PacketMakerService {
 
 	boolean createPacket(String containerRootFolder, String regId, String dataFilePath, String type, String preregId,
 			String contextKey) throws Exception {
-		String packetRootFolder = getPacketRoot(getProcessRoot(containerRootFolder , contextKey), regId, type);
+		String packetRootFolder = getPacketRoot(getProcessRoot(containerRootFolder, contextKey), regId, type);
 		String templateFile = getIdJSONFileLocation(packetRootFolder);
-		String process=VariableManager.getVariableValue(contextKey, "process").toString();
+		String process = VariableManager.getVariableValue(contextKey, "process").toString();
 		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
 		String officerId = null;
 		String supervisorId = null;
 		String officerP;
 		String supervisorP;
-		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
+		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
 
 		String dataToMerge = null;
 		if (dataFilePath != null)
 			dataToMerge = Files.readString(Path.of(dataFilePath));
-		JSONObject jb=null;
-			jb = new JSONObject(dataToMerge).getJSONObject(IDENTITY);
+		JSONObject jb = null;
+		jb = new JSONObject(dataToMerge).getJSONObject(IDENTITY);
 		// workaround for MOSIP-18123
 
 		JSONObject jb1 = new JSONObject(dataToMerge);
 		List<String> jsonList = jb.keySet().stream().filter(j -> j.startsWith("proof")).collect(Collectors.toList());
 		jsonList.forEach(o -> {
-				jb1.getJSONObject(IDENTITY).getJSONObject(o).put(VALUE, o);
+			jb1.getJSONObject(IDENTITY).getJSONObject(o).put(VALUE, o);
 
-				jb1.getJSONObject(IDENTITY).getJSONObject(o).remove("refNumber");
+			jb1.getJSONObject(IDENTITY).getJSONObject(o).remove("refNumber");
 		});
 
 		dataToMerge = jb1.toString();
@@ -549,7 +561,7 @@ public class PacketMakerService {
 						VariableManager.getVariableValue(contextKey, MOUNTPATH).toString()
 								+ VariableManager.getVariableValue(contextKey, MOSIP_TEST_TEMP).toString(),
 						contextKey.replace(CONTEXT, ""), regId + "_invalidIds.json");
-//To Do check				Files.createDirectories(path.getParent());
+				// To Do check Files.createDirectories(path.getParent());
 				try {
 					Files.createFile(path);
 				} catch (FileAlreadyExistsException e) {
@@ -569,8 +581,8 @@ public class PacketMakerService {
 				updatePacketMetaInfo(packetRootFolder, METADATA, "preRegistrationId", preregId, true);
 
 			String invalidDateValue = VariableManager
-			        .getVariableValue(contextKey, "invalidDateFlag")
-			        .toString();
+					.getVariableValue(contextKey, "invalidDateFlag")
+					.toString();
 
 			if (invalidDateValue.equals("invalidCreationDate")) {
 				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", null, true);
@@ -584,6 +596,8 @@ public class PacketMakerService {
 			}
 			updatePacketMetaInfo(packetRootFolder, METADATA, "machineId", machineId, false);
 			updatePacketMetaInfo(packetRootFolder, METADATA, "centerId", centerId, false);
+			updatePacketMetaInfo(packetRootFolder, METADATA, "Registration Client Version Number",
+					getRegistrationClientVersion(contextKey), false);
 			updatePacketMetaInfo(packetRootFolder, METADATA, "registrationType",
 					StringUtils.capitalize(process.toLowerCase()), false);
 
@@ -673,8 +687,8 @@ public class PacketMakerService {
 		VariableManager.setVariableValue(contextKey, "META_INFO-META_DATA-centerId", centerId != null ? centerId : "");
 		CommonUtil.deleteOldTempDir(
 				VariableManager.getVariableValue(contextKey, MOUNTPATH).toString()
-				+ VariableManager.getVariableValue(contextKey, MOSIP_TEST_TEMP).toString()+"/"+
-		contextKey.replace(CONTEXT, "")+"/"+ regId + "_schema.json");
+						+ VariableManager.getVariableValue(contextKey, MOSIP_TEST_TEMP).toString() + "/" +
+						contextKey.replace(CONTEXT, "") + "/" + regId + "_schema.json");
 		return true;
 	}
 
@@ -691,11 +705,12 @@ public class PacketMakerService {
 		if (encryptedHashFlag.equalsIgnoreCase("invalidEncryptedHash") && type.equals("id"))
 			encryptedHash = "INVALID_ENCRYPTED_HASH";
 		else
-			encryptedHash = CryptoUtil.encodeToURLSafeBase64(HMACUtils2.generateHash(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + ".zip"))));
-		
+			encryptedHash = CryptoUtil.encodeToURLSafeBase64(
+					HMACUtils2.generateHash(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + ".zip"))));
+
 		String signaturevalue = VariableManager.getVariableValue(contextKey, "signature").toString();
-		String signature="";
-		if(signaturevalue.equalsIgnoreCase("invalidSignature")){
+		String signature = "";
+		if (signaturevalue.equalsIgnoreCase("invalidSignature")) {
 			String newKey = contextKey.replaceAll("(?<=_S)\\d+(?=_context)", "0");
 			signature = Base64.getUrlEncoder().withoutPadding().encodeToString(
 					cryptoUtil.sign(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + UNENCZIP)), newKey));
@@ -720,7 +735,7 @@ public class PacketMakerService {
 		}
 
 		String containerMetaDataFileLocation = containerRootFolder + JSON;
-		return fixContainerMetaData(containerMetaDataFileLocation, regId, type, encryptedHash, signature , contextKey);
+		return fixContainerMetaData(containerMetaDataFileLocation, regId, type, encryptedHash, signature, contextKey);
 	}
 
 	boolean packContainer(String containerRootFolder, String contextKey) throws Exception {
@@ -760,9 +775,9 @@ public class PacketMakerService {
 
 	public synchronized boolean zipAndEncrypt(Path zipSrcFolder, String contextKey) throws Exception {
 		Path finalZipFile = Path.of(zipSrcFolder + UNENCZIP);
-		String centerId= VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
-		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
-				
+		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
+		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
+
 		// Use buffered streams
 		try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(
 				new FileOutputStream(finalZipFile.toFile()))) {
@@ -819,8 +834,9 @@ public class PacketMakerService {
 		return new File(packetRootFolder + File.separator + "ID".toUpperCase() + JSON).toString();
 	}
 
-	private String getProcessRoot(String containerRootFolder , String contextKey) {
-		return Path.of(containerRootFolder, src, VariableManager.getVariableValue(contextKey, "process").toString()).toString();
+	private String getProcessRoot(String containerRootFolder, String contextKey) {
+		return Path.of(containerRootFolder, src, VariableManager.getVariableValue(contextKey, "process").toString())
+				.toString();
 	}
 
 	private String getPacketRoot(String processRootFolder, String rid, String type) {
@@ -831,10 +847,11 @@ public class PacketMakerService {
 		return Path.of(processRootFolder, rid + UNDERSCORE + type.toLowerCase() + JSON).toString();
 	}
 
-	private String createTempTemplate(String templatePacket, String rid, String contextKey) throws IOException, SecurityException {
+	private String createTempTemplate(String templatePacket, String rid, String contextKey)
+			throws IOException, SecurityException {
 		Path sourceDirectory = Paths.get(templatePacket);
-		String centerId= VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
-		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
+		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
+		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
 		String tempDir = null;
 		if (VariableManager.getVariableValue(contextKey, PACKETPATH).toString().equals(""))
 			tempDir = workDirectory + File.separator + rid + "-" + centerId + "_" + machineId + "-"
@@ -844,12 +861,13 @@ public class PacketMakerService {
 					+ centerId + "_" + machineId + "-" + getcurrentTimeStamp();
 		Path targetDirectory = Paths.get(tempDir);
 		FileSystemUtils.copyRecursively(sourceDirectory, targetDirectory);
-		setupTemplateName(tempDir, rid , contextKey);
+		setupTemplateName(tempDir, rid, contextKey);
 		return targetDirectory.toString();
 	}
 
-	private void setupTemplateName(String templateRootPath, String regId , String contextKey) throws SecurityException {
-		String finalPath = templateRootPath + File.separator + src + File.separator + VariableManager.getVariableValue(contextKey, "process").toString();
+	private void setupTemplateName(String templateRootPath, String regId, String contextKey) throws SecurityException {
+		String finalPath = templateRootPath + File.separator + src + File.separator
+				+ VariableManager.getVariableValue(contextKey, "process").toString();
 		File rootFolder = new File(finalPath);
 		File[] listFiles = rootFolder.listFiles();
 		boolean assignValue = false;
@@ -870,8 +888,8 @@ public class PacketMakerService {
 	}
 
 	private boolean fixContainerMetaData(String fileToFix, String rid, String type, String encryptedHash,
-			String signature , String contextKey) throws IOException, Exception {
-		String process =VariableManager.getVariableValue(contextKey, "process").toString();
+			String signature, String contextKey) throws IOException, Exception {
+		String process = VariableManager.getVariableValue(contextKey, "process").toString();
 		Map<String, String> metaData = new HashMap();
 		metaData.put("process", process);
 		metaData.put("creationdate", APIRequestUtil.getUTCDateTime(null));
@@ -939,8 +957,8 @@ public class PacketMakerService {
 	}
 
 	private String generateRegId(String contextKey) {
-		String centerId= VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
-		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
+		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
+		String machineId = VariableManager.getVariableValue(contextKey, "machineid").toString();
 		SimpleDateFormat f = new SimpleDateFormat("yyyyMMddHHmmss");
 		f.setTimeZone(TimeZone.getTimeZone("UTC"));
 		String currUTCTime = f.format(new Date());
@@ -1049,8 +1067,7 @@ public class PacketMakerService {
 	 * 
 	 * return sequence; }
 	 */
-	
-	
+
 	private LinkedList<String> updateHashSequence(JSONObject metaInfo, String parentKey, String seqName,
 			LinkedList<String> sequence, List<String> files) {
 		// Early exit if the files list is empty or null
@@ -1104,33 +1121,33 @@ public class PacketMakerService {
 	 * CommonUtil.write(Path.of(packetRootFolder, PACKET_META_FILENAME),
 	 * jsonObject.toString().getBytes(UTF8)); }
 	 */
-	
+
 	private void updatePacketMetaInfo(String packetRootFolder, String parentKey, String key, String value,
 			boolean parentLevel) throws Exception {
-			String metaInfo_json = Files.readString(Path.of(packetRootFolder, PACKET_META_FILENAME));
-			JSONObject jsonObject = new JSONObject(metaInfo_json);
-			JSONObject identityObj = jsonObject.getJSONObject(IDENTITY);
-			if (parentLevel)
-				identityObj.put(key, value);
-			boolean updated = false;
-			if (identityObj.has(parentKey)) {
-				JSONArray metadata = identityObj.getJSONArray(parentKey);
-				for (int i = 0; i < metadata.length(); i++) {
-					JSONObject metaItem = metadata.getJSONObject(i);
-					if (metaItem.getString(LABEL).equals(key)) {
-						metaItem.put(VALUE, value);
-						updated = true;
-					}
+		String metaInfo_json = Files.readString(Path.of(packetRootFolder, PACKET_META_FILENAME));
+		JSONObject jsonObject = new JSONObject(metaInfo_json);
+		JSONObject identityObj = jsonObject.getJSONObject(IDENTITY);
+		if (parentLevel)
+			identityObj.put(key, value);
+		boolean updated = false;
+		if (identityObj.has(parentKey)) {
+			JSONArray metadata = identityObj.getJSONArray(parentKey);
+			for (int i = 0; i < metadata.length(); i++) {
+				JSONObject metaItem = metadata.getJSONObject(i);
+				if (metaItem.getString(LABEL).equals(key)) {
+					metaItem.put(VALUE, value);
+					updated = true;
 				}
 			}
-			if (!updated) {
-				JSONObject rid = new JSONObject();
-				rid.put(LABEL, key);
-				rid.put(VALUE, value);
-				jsonObject.getJSONObject(IDENTITY).getJSONArray(parentKey).put(rid);
-			}
-			CommonUtil.write(Path.of(packetRootFolder, PACKET_META_FILENAME), jsonObject.toString().getBytes(UTF8));
 		}
+		if (!updated) {
+			JSONObject rid = new JSONObject();
+			rid.put(LABEL, key);
+			rid.put(VALUE, value);
+			jsonObject.getJSONObject(IDENTITY).getJSONArray(parentKey).put(rid);
+		}
+		CommonUtil.write(Path.of(packetRootFolder, PACKET_META_FILENAME), jsonObject.toString().getBytes(UTF8));
+	}
 
 	private String generateCaseConvertedString(String inputString) {
 		StringBuilder result = new StringBuilder();
@@ -1159,6 +1176,31 @@ public class PacketMakerService {
 				if (RestClient.isDebugEnabled(contextKey))
 					logger.info("Failed to update audit.json", e);
 			}
+		}
+	}
+
+	public String getRegistrationClientVersion(String contextKey) {
+		String baseUrl = VariableManager
+				.getVariableValue(contextKey, "mosip.test.baseurl").toString()
+				.replaceAll("api-internal", "regclient")
+				+ VariableManager
+						.getVariableValue(
+								VariableManager.NS_DEFAULT,
+								"regClientVersion")
+						.toString();
+		io.restassured.response.Response response = RestClient.getWithoutCookie(baseUrl);
+		try {
+			String xml = response.getBody().asString();
+			Document doc = DocumentBuilderFactory
+					.newInstance()
+					.newDocumentBuilder()
+					.parse(new ByteArrayInputStream(xml.getBytes()));
+
+			NodeList nodeList = doc.getElementsByTagName("version");
+			return nodeList.item(0).getTextContent();
+		} catch (Exception e) {
+			throw new RuntimeException(
+					"Failed to parse version from metadata XML", e);
 		}
 	}
 }

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -1035,10 +1035,23 @@ public class PacketMakerService {
 
 	private List<String> getBiometricFiles(String packetRootFolder) {
 		List<String> paths = new ArrayList<>();
-		File packetFolder = Path.of(packetRootFolder).toFile();
+		Path baseDir = Paths.get(packetRootFolder)
+				.toAbsolutePath()
+				.normalize();
+		File packetFolder = baseDir.toFile();
 		File[] biometricFiles = packetFolder.listFiles((d, name) -> name.endsWith(".xml"));
+		if (biometricFiles == null) {
+			return paths;
+		}
 		for (File file : biometricFiles) {
-			paths.add(file.getAbsolutePath());
+			Path filePath = file.toPath()
+					.toAbsolutePath()
+					.normalize();
+			if (!filePath.startsWith(baseDir)) {
+				throw new SecurityException(
+						"Invalid file path detected: " + filePath);
+			}
+			paths.add(filePath.toString());
 		}
 		return paths;
 	}

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -511,8 +511,9 @@ public class PacketMakerService {
 
 	boolean createPacket(String containerRootFolder, String regId, String dataFilePath, String type, String preregId,
 			String contextKey) throws Exception {
-		String packetRootFolder = getPacketRoot(getProcessRoot(containerRootFolder, contextKey), regId, type);
-		String templateFile = getIdJSONFileLocation(packetRootFolder);
+		Path packetRootFolder = resolvePacketRootFolder(
+				getPacketRoot(getProcessRoot(containerRootFolder, contextKey), regId, type), contextKey);
+		String templateFile = getIdJSONFileLocation(packetRootFolder.toString());
 		String process = VariableManager.getVariableValue(contextKey, "process").toString();
 		String centerId = VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
 		String officerId = null;
@@ -581,30 +582,30 @@ public class PacketMakerService {
 				return false;
 			}
 
-			updatePacketMetaInfo(packetRootFolder, METADATA, "registrationId", regId, true);
+			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "registrationId", regId, true);
 			if (preregId != null && !preregId.equalsIgnoreCase("0")) // newly added
 
-				updatePacketMetaInfo(packetRootFolder, METADATA, "preRegistrationId", preregId, true);
+				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "preRegistrationId", preregId, true);
 
 			String invalidDateValue = VariableManager
 					.getVariableValue(contextKey, "invalidDateFlag")
 					.toString();
 
 			if (invalidDateValue.equals("invalidCreationDate")) {
-				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", null, true);
+				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "creationDate", null, true);
 			} else if (invalidDateValue.contains("CreationDate")) {
 				String offsetValue = invalidDateValue.split("=")[1];
 				String updatedDate = APIRequestUtil.getAdjustedUTCDate(offsetValue);
-				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", updatedDate, true);
+				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "creationDate", updatedDate, true);
 			} else {
-				updatePacketMetaInfo(packetRootFolder, METADATA, "creationDate", APIRequestUtil.getUTCDateTime(null),
-						true);
+				updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "creationDate",
+						APIRequestUtil.getUTCDateTime(null), true);
 			}
-			updatePacketMetaInfo(packetRootFolder, METADATA, "machineId", machineId, false);
-			updatePacketMetaInfo(packetRootFolder, METADATA, "centerId", centerId, false);
-			updatePacketMetaInfo(packetRootFolder, METADATA, "Registration Client Version Number",
+			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "machineId", machineId, false);
+			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "centerId", centerId, false);
+			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "Registration Client Version Number",
 					getRegistrationClientVersion(contextKey), false);
-			updatePacketMetaInfo(packetRootFolder, METADATA, "registrationType",
+			updatePacketMetaInfo(packetRootFolder.toString(), METADATA, "registrationType",
 					StringUtils.capitalize(process.toLowerCase()), false);
 
 			// ToRead Context file
@@ -622,7 +623,7 @@ public class PacketMakerService {
 
 			if (!VariableManager.getVariableValue(contextKey, "invalidOfficerIDFlag").toString()
 					.equals("invalidOfficerID")) {
-				updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "officerId", officerId, false);
+				updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "officerId", officerId, false);
 			}
 			supervisorId = p.getProperty(MOSIPTEST_REGCLIENT_SUPERVISORID);
 
@@ -630,7 +631,7 @@ public class PacketMakerService {
 					.equalsIgnoreCase("true"))
 				supervisorId = generateCaseConvertedString(supervisorId);
 
-			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "supervisorId", supervisorId, false);
+			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "supervisorId", supervisorId, false);
 
 			// officerP
 			officerP = p.getProperty(MOSIP_TEST_REGCLIENT_PASSWORD);
@@ -640,7 +641,7 @@ public class PacketMakerService {
 				officerP = "true"; // valid
 			else
 				officerP = FALSE; // null
-			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "officerPassword", officerP, false);
+			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "officerPassword", officerP, false);
 
 			// supervisorP
 			supervisorP = p.getProperty(MOSIP_TEST_REGCLIENT_supervisorP);
@@ -650,33 +651,33 @@ public class PacketMakerService {
 				supervisorP = "true"; // valid
 			else
 				supervisorP = FALSE; // null
-			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "supervisorPassword", supervisorP, false);
+			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "supervisorPassword", supervisorP, false);
 
 			// officerBiometricFileName
 			officerBiometricFileName = p.getProperty("mosip.test.regclient.officerBiometricFileName");
 			if (officerBiometricFileName != null && officerBiometricFileName.length() > 1) {
 			} else
 				officerBiometricFileName = null;
-			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "officerBiometricFileName", officerBiometricFileName,
-					false);
+			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "officerBiometricFileName",
+					officerBiometricFileName, false);
 
 			// supervisorBiometricFileName
 			supervisorBiometricFileName = p.getProperty("mosip.test.regclient.supervisorBiometricFileName");
 			if (supervisorBiometricFileName != null && supervisorBiometricFileName.length() > 1) {
 			} else
 				supervisorBiometricFileName = null;
-			updatePacketMetaInfo(packetRootFolder, OPERATIONSDATA, "supervisorBiometricFileName",
+			updatePacketMetaInfo(packetRootFolder.toString(), OPERATIONSDATA, "supervisorBiometricFileName",
 					supervisorBiometricFileName, false);
 
-			updateAudit(packetRootFolder, regId, contextKey);
+			updateAudit(packetRootFolder.toString(), regId, contextKey);
 
 			LinkedList<String> sequence = updateHashSequence1(packetRootFolder);
 			LinkedList<String> operations_seq = updateHashSequence2(packetRootFolder);
 			if (preregId != null && preregId.equals("01")) // to generte invalid hash data
 			{
-				CommonUtil.write(Path.of(packetRootFolder, PACKET_DATA_HASH_FILENAME),
+				CommonUtil.write(packetRootFolder.resolve(PACKET_DATA_HASH_FILENAME),
 						"PACKET_DATA_HASH_INVALID_DATA".getBytes());
-				CommonUtil.write(Path.of(packetRootFolder, PACKET_OPERATION_HASH_FILENAME),
+				CommonUtil.write(packetRootFolder.resolve(PACKET_OPERATION_HASH_FILENAME),
 						"PACKET_OPERATION_HASH_INVALID_DATA".getBytes());
 			} else {
 				updatePacketDataHash(packetRootFolder, sequence, PACKET_DATA_HASH_FILENAME, contextKey);
@@ -979,9 +980,9 @@ public class PacketMakerService {
 		return centerId + machineId + counter + currUTCTime;
 	}
 
-	private LinkedList<String> updateHashSequence1(String packetRootFolder) throws Exception {
+	private LinkedList<String> updateHashSequence1(Path packetRootFolder) throws Exception {
 		LinkedList<String> sequence = new LinkedList<>();
-		Path metaInfoPath = Path.of(packetRootFolder, PACKET_META_FILENAME);
+		Path metaInfoPath = packetRootFolder.resolve(PACKET_META_FILENAME);
 		JSONObject metaInfo;
 		try (BufferedReader reader = Files.newBufferedReader(metaInfoPath, StandardCharsets.UTF_8)) {
 			metaInfo = new JSONObject(reader.lines().collect(Collectors.joining()));
@@ -998,9 +999,9 @@ public class PacketMakerService {
 		return sequence;
 	}
 
-	private LinkedList<String> updateHashSequence2(String packetRootFolder) throws Exception {
+	private LinkedList<String> updateHashSequence2(Path packetRootFolder) throws Exception {
 		LinkedList<String> sequence = new LinkedList<>();
-		Path metaInfoPath = Path.of(packetRootFolder, PACKET_META_FILENAME);
+		Path metaInfoPath = packetRootFolder.resolve(PACKET_META_FILENAME);
 		JSONObject metaInfo;
 		try (BufferedReader reader = Files.newBufferedReader(metaInfoPath, StandardCharsets.UTF_8)) {
 			metaInfo = new JSONObject(reader.lines().collect(Collectors.joining()));
@@ -1015,7 +1016,7 @@ public class PacketMakerService {
 		return sequence;
 	}
 
-	private void updatePacketDataHash(String packetRootFolder, LinkedList<String> sequence, String fileName,
+	private void updatePacketDataHash(Path packetRootFolder, LinkedList<String> sequence, String fileName,
 			String contextKey) throws Exception {
 		MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -1031,69 +1032,83 @@ public class PacketMakerService {
 			logger.info("sequence packetDataHash >> {} ", packetDataHash);
 			logger.info("sequence packetDataHash2 >> {} ", packetDataHash2);
 		}
-		CommonUtil.write(Path.of(packetRootFolder, fileName), packetDataHash2.getBytes());
+		CommonUtil.write(packetRootFolder.resolve(fileName), packetDataHash2.getBytes());
 	}
 
-	private List<String> getBiometricFiles(String packetRootFolder) {
+	private Path resolvePacketRootFolder(String packetRootFolder, String contextKey) throws IOException {
+		Path allowedBaseDirectory = resolvePacketBaseDirectory(contextKey);
+		Path normalizedPacketFolder = Paths.get(packetRootFolder)
+				.toAbsolutePath()
+				.normalize();
 
-		List<String> paths = new ArrayList<>();
-
-		try {
-
-			File packetFolder = new File(packetRootFolder).getCanonicalFile();
-
-			// Validate directory
-			if (!packetFolder.exists() || !packetFolder.isDirectory()) {
-				return paths;
-			}
-
-			File[] biometricFiles = packetFolder.listFiles(
-					(dir, name) -> name != null && name.endsWith(".xml"));
-
-			if (biometricFiles == null) {
-				return paths;
-			}
-
-			for (File file : biometricFiles) {
-
-				File canonicalFile = file.getCanonicalFile();
-
-				// Ensure file stays inside base directory
-				if (!canonicalFile.getPath()
-						.startsWith(packetFolder.getPath())) {
-
-					throw new SecurityException(
-							"Invalid file path: " + canonicalFile);
-				}
-
-				paths.add(canonicalFile.getAbsolutePath());
-			}
-
-		} catch (IOException e) {
-			throw new RuntimeException(
-					"Error reading biometric files", e);
+		if (!normalizedPacketFolder.startsWith(allowedBaseDirectory)) {
+			throw new SecurityException("Invalid packet folder path: " + normalizedPacketFolder);
 		}
 
-		return paths;
+		if (!Files.isDirectory(normalizedPacketFolder)) {
+			throw new SecurityException("Packet folder does not exist: " + normalizedPacketFolder);
+		}
+
+		Path canonicalPacketFolder = normalizedPacketFolder.toRealPath();
+		if (!canonicalPacketFolder.startsWith(allowedBaseDirectory)) {
+			throw new SecurityException("Invalid packet folder path: " + canonicalPacketFolder);
+		}
+
+		return canonicalPacketFolder;
+	}
+
+	private Path resolvePacketBaseDirectory(String contextKey) {
+		if (contextKey != null) {
+			Object configuredPacketPath = VariableManager.getVariableValue(contextKey, PACKETPATH);
+			if (configuredPacketPath != null && StringUtils.hasText(configuredPacketPath.toString())) {
+				return Paths.get(configuredPacketPath.toString()).toAbsolutePath().normalize();
+			}
+		}
+		return Paths.get(workDirectory).toAbsolutePath().normalize();
+	}
+
+	private List<String> getBiometricFiles(Path packetRootFolder) {
+		return getPacketFiles(packetRootFolder, path -> path.getFileName().toString().endsWith(".xml"));
 	}
 
 	private List<String> getDemographicDocFiles(String packetRootFolder) {
-		List<String> paths = new ArrayList<>();
-		File packetFolder = Path.of(packetRootFolder).toFile();
-		File[] documents = packetFolder
-				.listFiles((d, name) -> name.endsWith(".pdf") || name.endsWith(".jpg") || name.equals("ID.json"));
-		for (File file : documents) {
-			paths.add(file.getAbsolutePath());
-		}
-		return paths;
+		return getPacketFiles(Paths.get(packetRootFolder).toAbsolutePath().normalize(),
+				path -> {
+					String fileName = path.getFileName().toString();
+					return fileName.endsWith(".pdf") || fileName.endsWith(".jpg") || fileName.equals("ID.json");
+				});
 	}
 
-	private List<String> getOperationsFiles(String packetRootFolder) {
+	private List<String> getDemographicDocFiles(Path packetRootFolder) {
+		return getPacketFiles(packetRootFolder,
+				path -> {
+					String fileName = path.getFileName().toString();
+					return fileName.endsWith(".pdf") || fileName.endsWith(".jpg") || fileName.equals("ID.json");
+				});
+	}
+
+	private List<String> getOperationsFiles(Path packetRootFolder) {
+		return getPacketFiles(packetRootFolder, path -> path.getFileName().toString().equals("audit.json"));
+	}
+
+	private List<String> getPacketFiles(Path packetRootFolder, DirectoryStream.Filter<Path> filter) {
 		List<String> paths = new ArrayList<>();
-		File packetFolder = Path.of(packetRootFolder).toFile();
-		File[] documents = packetFolder.listFiles((d, name) -> name.equals("audit.json"));
-		for (File file : documents) {
-			paths.add(file.getAbsolutePath());
+		if (!Files.isDirectory(packetRootFolder)) {
+			return paths;
+		}
+
+		try (DirectoryStream<Path> files = Files.newDirectoryStream(packetRootFolder, filter)) {
+			for (Path file : files) {
+				Path canonicalFile = file.toRealPath();
+				if (!canonicalFile.startsWith(packetRootFolder)) {
+					throw new SecurityException("Invalid file path: " + canonicalFile);
+				}
+				if (Files.isRegularFile(canonicalFile)) {
+					paths.add(canonicalFile.toString());
+				}
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Error reading packet files", e);
 		}
 		return paths;
 	}

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -590,6 +590,7 @@ public class PacketMakerService {
 			updatePacketMetaInfo(packetRootFolder, METADATA, "centerId", centerId, false);
 			updatePacketMetaInfo(packetRootFolder, METADATA, "registrationType",
 					StringUtils.capitalize(process.toLowerCase()), false);
+
             updatePacketMetaInfo(packetRootFolder, METADATA, "Registration Client Version Number",
 					getRegistrationClientVersion(contextKey), false);
 			// ToRead Context file

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketMakerService.java
@@ -326,14 +326,19 @@ public class PacketMakerService {
 				} else {
 					originalFileName = originalFileName.replaceFirst("^[^_]*_", "");
 				}
+				Path baseDir = Paths.get(templateLocation, source, processArg, "rid_id")
+						.normalize();
 
-				Path target = Paths.get(templateLocation + File.separator + source + File.separator +
-						processArg + File.separator + "rid_id", originalFileName);
+				Path target = baseDir.resolve(originalFileName).normalize();
+
+				if (!target.startsWith(baseDir)) {
+					throw new SecurityException("Invalid file path detected: " + originalFileName);
+				}
 
 				try {
 					Files.copy(sourceprereg, target, StandardCopyOption.REPLACE_EXISTING);
 				} catch (IOException e) {
-					e.printStackTrace(); // or log the error appropriately
+					e.printStackTrace(); // Replace with proper logging
 				}
 			}
 		}
@@ -700,14 +705,21 @@ public class PacketMakerService {
 		}
 		String encryptedHashFlag = VariableManager.getVariableValue(contextKey, "invalidEncryptedHashFlag").toString();
 		String encryptedHash = null;
-
-		// Make encrypted hash as invalid if "invalidEncryptedHashFlag --yes"
-		if (encryptedHashFlag.equalsIgnoreCase("invalidEncryptedHash") && type.equals("id"))
+		Path baseDir = Paths.get(containerRootFolder).normalize();
+		Path zipPath = Paths.get(containerRootFolder + ".zip")
+				.normalize();
+		if (!zipPath.startsWith(baseDir.getParent())) {
+			throw new SecurityException(
+					"Invalid zip path detected: " + zipPath);
+		}
+		if (encryptedHashFlag.equalsIgnoreCase("invalidEncryptedHash")
+				&& type.equals("id")) {
 			encryptedHash = "INVALID_ENCRYPTED_HASH";
-		else
+		} else {
+			byte[] fileBytes = Files.readAllBytes(zipPath);
 			encryptedHash = CryptoUtil.encodeToURLSafeBase64(
-					HMACUtils2.generateHash(Files.readAllBytes(Path.of(Path.of(containerRootFolder) + ".zip"))));
-
+					HMACUtils2.generateHash(fileBytes));
+		}
 		String signaturevalue = VariableManager.getVariableValue(contextKey, "signature").toString();
 		String signature = "";
 		if (signaturevalue.equalsIgnoreCase("invalidSignature")) {

--- a/mosip-packet-creator/src/main/resources/dockersupport/centralized/mosip-packet-creator/resource/config/default.properties
+++ b/mosip-packet-creator/src/main/resources/dockersupport/centralized/mosip-packet-creator/resource/config/default.properties
@@ -67,6 +67,7 @@ mockABISsetExpectaion=v1/mock-abis-service/config/expectation
 deleteMockAbisExpectations=v1/mock-abis-service/config/expectation
 residentCredentialAPI=resident/v1/req/credential/
 bulkupload=v1/admin/bulkupload
+regClientVersion=registration-client/maven-metadata.xml
 ## mds port loop count ##
 mdsPortLoopCount=20
 

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
@@ -201,10 +201,10 @@ public class RestClient {
 
 			}
 			if (response != null) {
-			    checkErrorResponse(response.getBody().asString(), url);
-			}else {
-			    throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
- 			}
+				checkErrorResponse(response.getBody().asString(), url);
+			} else {
+				throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
+			}
 
 		} catch (ServiceException se) {
 			throw se;
@@ -358,16 +358,22 @@ public class RestClient {
 		return fullResp;
 	}
 
-	public static Response getWithoutParams(String url, String cookie) {
+	public static Response getWithoutCookie(String url) {
 
-		Cookie.Builder builder = new Cookie.Builder("Authorization", cookie);
-		Response getResponse;
-		getResponse = given().cookie(builder.build()).relaxedHTTPSValidation().log().all().when().get(url);
-		return getResponse;
+		Response response;
+
+		response = given()
+				.relaxedHTTPSValidation()
+				.log().all()
+				.when()
+				.get(url);
+
+		return response;
 	}
 
 	// method for GET request without authentication
-	public static JSONObject getWithoutAuth(String url, JSONObject requestParams, JSONObject pathParam, String contextKey)
+	public static JSONObject getWithoutAuth(String url, JSONObject requestParams, JSONObject pathParam,
+			String contextKey)
 			throws Exception {
 
 		Response response = null;
@@ -506,7 +512,7 @@ public class RestClient {
 				logger.error("GET failed for url {} : {}", url, e.getMessage(), e);
 				throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "REST_CALL_FAIL", url, e, e.getMessage());
 			}
-		}else 
+		} else
 			throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
 
 		return new JSONObject(response.getBody().asString()).getJSONObject(dataKey);
@@ -552,56 +558,56 @@ public class RestClient {
 			logger.error("POST (file upload) failed for url {} : {}", url, e.getMessage(), e);
 			throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "REST_CALL_FAIL", url, e, e.getMessage());
 		}
-		
-         return new JSONObject(response.getBody().asString()).getJSONObject(dataKey);
-     }
 
-     public static JSONObject uploadFiles(String url, List<String> filePaths, JSONObject requestData, String contextKey)
-             throws Exception {
-         String role = ADMIN;
+		return new JSONObject(response.getBody().asString()).getJSONObject(dataKey);
+	}
 
-			if (!isValidToken(role, contextKey)) {
-				initToken_admin(contextKey);
+	public static JSONObject uploadFiles(String url, List<String> filePaths, JSONObject requestData, String contextKey)
+			throws Exception {
+		String role = ADMIN;
+
+		if (!isValidToken(role, contextKey)) {
+			initToken_admin(contextKey);
+		}
+
+		Response response = null;
+		RequestSpecification spec = null;
+		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+
+		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
+
+		if (isDebugEnabled(contextKey))
+			spec = given().log().all().cookie(kukki);
+		else
+			spec = given().cookie(kukki);
+		for (String fName : filePaths)
+			spec = spec.multiPart("files", new File(fName));
+		if (requestData != null) {
+			Iterator<String> paramKeys = requestData.keys();
+			while (paramKeys.hasNext()) {
+				String key = paramKeys.next();
+				spec = spec.formParam(key, requestData.get(key));
+
 			}
+		}
 
-         Response response = null;
-         RequestSpecification spec = null;
-         String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
-
-         Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
-
-         if (isDebugEnabled(contextKey))
-             spec = given().log().all().cookie(kukki);
-         else
-             spec = given().cookie(kukki);
-         for (String fName : filePaths)
-             spec = spec.multiPart("files", new File(fName));
-         if (requestData != null) {
-             Iterator<String> paramKeys = requestData.keys();
-             while (paramKeys.hasNext()) {
-                 String key = paramKeys.next();
-                 spec = spec.formParam(key, requestData.get(key));
-
-             }
-         }
-
-         if (isDebugEnabled(contextKey))
-             response = spec.post(url).then().log().all().extract().response();
-         else
-             response = spec.post(url);
-			if (response == null) {
-				throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
-			}
-        try {
-            checkErrorResponse(response.getBody().asString(), url);
-        } catch (ServiceException se) {
-            throw se;
-        } catch (Exception e) {
-            logger.error("POST (files upload) failed for url {} : {}", url, e.getMessage(), e);
-            throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "REST_CALL_FAIL", url, e, e.getMessage());
-        }
-         return new JSONObject(response.getBody().asString()).getJSONObject(dataKey);
-     }
+		if (isDebugEnabled(contextKey))
+			response = spec.post(url).then().log().all().extract().response();
+		else
+			response = spec.post(url);
+		if (response == null) {
+			throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
+		}
+		try {
+			checkErrorResponse(response.getBody().asString(), url);
+		} catch (ServiceException se) {
+			throw se;
+		} catch (Exception e) {
+			logger.error("POST (files upload) failed for url {} : {}", url, e.getMessage(), e);
+			throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "REST_CALL_FAIL", url, e, e.getMessage());
+		}
+		return new JSONObject(response.getBody().asString()).getJSONObject(dataKey);
+	}
 
 	public static JSONObject postNoAuth(String url, JSONObject jsonRequest, String contextKey) throws Exception {
 		return postNoAuth(url, jsonRequest, ADMIN, contextKey);
@@ -1509,59 +1515,57 @@ public class RestClient {
 
 	private static void checkErrorResponse(String response, String url) {
 
-        // NULL or empty response
-        if (response == null || response.trim().isEmpty()) {
-            throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
-        }
+		// NULL or empty response
+		if (response == null || response.trim().isEmpty()) {
+			throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
+		}
 
-        JSONObject json;
-        try {
-            json = new JSONObject(response);
-        } catch (Exception e) {
-            throw new ServiceException(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "REST_INVALID_RESPONSE",
-                    url,
-                    e,
-                    response
-            );
+		JSONObject json;
+		try {
+			json = new JSONObject(response);
+		} catch (Exception e) {
+			throw new ServiceException(
+					HttpStatus.INTERNAL_SERVER_ERROR,
+					"REST_INVALID_RESPONSE",
+					url,
+					e,
+					response);
 
-        }
+		}
 
-        // ---- NO errors key → SUCCESS ----
-        if (!json.has(errorKey)) {
-            return;
-        }
+		// ---- NO errors key → SUCCESS ----
+		if (!json.has(errorKey)) {
+			return;
+		}
 
-        Object errObject = json.get(errorKey);
+		Object errObject = json.get(errorKey);
 
-        // ---- errors : null → SUCCESS ----
-        if (errObject == JSONObject.NULL) {
-            return;
-        }
+		// ---- errors : null → SUCCESS ----
+		if (errObject == JSONObject.NULL) {
+			return;
+		}
 
-        // ---- errors : [] → SUCCESS ----
-        if (errObject instanceof JSONArray) {
-            JSONArray errors = (JSONArray) errObject;
-            if (errors.isEmpty()) {
-                return;
-            }
+		// ---- errors : [] → SUCCESS ----
+		if (errObject instanceof JSONArray) {
+			JSONArray errors = (JSONArray) errObject;
+			if (errors.isEmpty()) {
+				return;
+			}
 
-            JSONObject err = errors.getJSONObject(0);
+			JSONObject err = errors.getJSONObject(0);
 			throw new ServiceException(HttpStatus.BAD_REQUEST, err.optString("errorCode", "UNKNOWN"), url, null,
 					err.optString("message", err.toString()));
-        }
+		}
 
-        // ---- errors : { } → ERROR ----
-        if (errObject instanceof JSONObject) {
-            JSONObject err = (JSONObject) errObject;
-        	throw new ServiceException(HttpStatus.BAD_REQUEST, err.optString("errorCode", "UNKNOWN"), url, null,
+		// ---- errors : { } → ERROR ----
+		if (errObject instanceof JSONObject) {
+			JSONObject err = (JSONObject) errObject;
+			throw new ServiceException(HttpStatus.BAD_REQUEST, err.optString("errorCode", "UNKNOWN"), url, null,
 					err.optString("message", err.toString()));
-        }
+		}
 
-        throw new ServiceException(HttpStatus.BAD_REQUEST, "UNKNOWN", url, null, errObject.toString());
+		throw new ServiceException(HttpStatus.BAD_REQUEST, "UNKNOWN", url, null, errObject.toString());
 	}
-
 
 	public String get(String uri, Properties queryParam) throws IOException {
 

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
@@ -1,6 +1,7 @@
 package io.mosip.testrig.dslrig.dataprovider.util;
 
 import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -360,14 +361,23 @@ public class RestClient {
 
 	public static Response getWithoutCookie(String url) {
 
-		Response response;
+		Response response = null;
+		try {
+			response = given()
+					.relaxedHTTPSValidation()
+					.log().all()
+					.when()
+					.get(url);
 
-		response = given()
-				.relaxedHTTPSValidation()
-				.log().all()
-				.when()
-				.get(url);
-
+			if (response == null) {
+				throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
+			}
+		} catch (ServiceException se) {
+			throw se;
+		} catch (Exception e) {
+			logger.error("GET failed for url {} : {}", url, e.getMessage(), e);
+			throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "REST_CALL_FAIL", url, e, e.getMessage());
+		}
 		return response;
 	}
 


### PR DESCRIPTION
MOSIP-32609- Added regclient version in DSL packet 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Packets now include a Registration Client Version Number in metadata.

* **Bug Fixes**
  * Ensured metadata updates are always written to disk to avoid lost updates.
  * Prevented path-traversal when copying documents; strengthened ZIP/encrypted-hash validation.
  * Improved REST call error handling with explicit no-response and failure reporting.

* **Refactor**
  * Simplified REST client request flows and adjusted unauthenticated GET behavior.

* **Configuration**
  * Added property to locate registration-client version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->