### PR TITLE
MOSIP-44866-DSL check a tag response for the age of resident

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/CheckTags.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/CheckTags.java
@@ -6,7 +6,11 @@ import org.json.JSONObject;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
 import io.mosip.testrig.apirig.dto.TestCaseDTO;
 import io.mosip.testrig.apirig.masterdata.testscripts.SimplePost;
 import io.mosip.testrig.apirig.testrunner.JsonPrecondtion;
@@ -85,7 +89,7 @@ public class CheckTags extends BaseTestCaseUtil implements StepInterface {
 
 	}
 
-	public static String comparePacketTags(String jsonFromServer, String jsonFromPacketCreator) {
+	public  String comparePacketTags(String jsonFromServer, String jsonFromPacketCreator) {
 		String tagMismatched = "";
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -94,14 +98,17 @@ public class CheckTags extends BaseTestCaseUtil implements StepInterface {
 			JsonNode nodePacketCreator = objectMapper.readTree(jsonFromPacketCreator);
 
 			// Convert JSON nodes to Map for easier comparison
-			Map<String, String> mapFromServer = objectMapper.convertValue(nodeFromServer, Map.class);
-			Map<String, String> mapPacketCreator = objectMapper.convertValue(nodePacketCreator, Map.class);
-
+			Map<String, String> mapFromServer = new TreeMap<>(objectMapper.convertValue(nodeFromServer, Map.class));
+			Map<String, String> mapPacketCreator = new TreeMap<>(
+					objectMapper.convertValue(nodePacketCreator, Map.class));
 			// Compare key-value pairs
 			for (Map.Entry<String, String> entry : mapFromServer.entrySet()) {
 				String key = entry.getKey();
 				String valueFromServer = entry.getValue();
 				String valuePacketCreator = mapPacketCreator.get(key);
+
+				valueFromServer = sortValue(valueFromServer);
+				valuePacketCreator = sortValue(valuePacketCreator);
 
 				if (valuePacketCreator != null && valuePacketCreator.equals(valueFromServer)) {
 					logger.info("Key :" + key + "has the same value in both JSONs: " + valueFromServer);
@@ -115,5 +122,16 @@ public class CheckTags extends BaseTestCaseUtil implements StepInterface {
 			logger.error(e.getMessage());
 		}
 		return tagMismatched;
+	}
+
+	private String sortValue(String value) {
+		if (value == null || value.isEmpty()) {
+			return value;
+		}
+
+		return Arrays.stream(value.split(","))
+				.map(String::trim)
+				.sorted()
+				.collect(Collectors.joining(","));
 	}
 }

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/DateOfBirthProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/DateOfBirthProvider.java
@@ -74,7 +74,7 @@ public class DateOfBirthProvider {
 			ageRange = ageRanges.get("ADULT");
 			break;
 		case RA_Minor:
-			ageGroup = "CHILD";
+			ageGroup = "MINOR";
 			ageRange = ageRanges.get("MINOR");
 			break;
 		case RA_Senior:
@@ -82,7 +82,7 @@ public class DateOfBirthProvider {
 			ageRange = ageRanges.get("ADULT");
 			break;
 		case RA_Infant:
-			ageGroup = "CHILD";
+			ageGroup = "INFANT";
 			ageRange = ageRanges.get("INFANT");
 			break;
 		default:


### PR DESCRIPTION
MOSIP-44866-DSL check a tag response for the age of resident

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced packet tag comparison to handle comma-separated values order-insensitively for more flexible matching.

* **Bug Fixes**
  * Refined age group categorization with more specific resident classification labels for accurate data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->