### PR TITLE
MOSIP-44808- Added new scanrios

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/GetResidentData.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/GetResidentData.java
@@ -33,6 +33,7 @@ public class GetResidentData extends BaseTestCaseUtil implements StepInterface {
 		Boolean bSkipGuardian = false;
 		String missFields = null;
 		String largeFace = null;
+		String obstructedFace = null;
 		String[] bioFlag = null;
 		HashMap<String, String> genderAndBioFlag = new HashMap<String, String>();
 		if (!step.getParameters().isEmpty() && step.getParameters().size() >= 3) {
@@ -53,6 +54,7 @@ public class GetResidentData extends BaseTestCaseUtil implements StepInterface {
 				genderAndBioFlag.put("Finger", "true");
 				genderAndBioFlag.put("Face", "true");
 				genderAndBioFlag.put("LargeFace", "false");
+				genderAndBioFlag.put("ObstructedFace", "false");
 
 			}
 
@@ -63,13 +65,22 @@ public class GetResidentData extends BaseTestCaseUtil implements StepInterface {
 				if ("true".equalsIgnoreCase(fourthParam) || "false".equalsIgnoreCase(fourthParam)) {
 					largeFace = fourthParam;
 					if (step.getParameters().size() > 4) {
-						missFields = step.getParameters().get(4).replaceAll("@@", ",");
+						String fifthParam = step.getParameters().get(4).trim();
+						if ("true".equalsIgnoreCase(fifthParam) || "false".equalsIgnoreCase(fifthParam)) {
+							obstructedFace = fifthParam;
+							if (step.getParameters().size() > 5) {
+								missFields = step.getParameters().get(5).replaceAll("@@", ",");
+							}
+						} else {
+							missFields = fifthParam.replaceAll("@@", ",");
+						}
 					}
 				} else {
 					missFields = fourthParam.replaceAll("@@", ",");
 				}
 			}
 			genderAndBioFlag.put("LargeFace", largeFace == null ? "false" : largeFace);
+			genderAndBioFlag.put("ObstructedFace", obstructedFace == null ? "false" : obstructedFace);
 
 		} else {
 			logger.warn("Input parameter missing [nofResident/bAdult/bSkipGuardian/gender]");

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
@@ -215,6 +215,9 @@ public class PacketUtility extends BaseTestCaseUtil {
 		if (genderAndBioFlag.containsKey("LargeFace")) {
 			residentAttrib.put("LargeFace", genderAndBioFlag.get("LargeFace"));
 		}
+		if (genderAndBioFlag.containsKey("ObstructedFace")) {
+			residentAttrib.put("ObstructedFace", genderAndBioFlag.get("ObstructedFace"));
+		}
 
 		if (missFields != null)
 			residentAttrib.put("Miss", missFields);

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -31616,6 +31616,67 @@
 		}
 	},
 	{
+		"Scenario": "242",
+		"Tag": "Positive_Test",
+		"Persona": "ResidentMaleAdult",
+		"Group": "New_Adult",
+		"Description": "Resident walks to the center and creates a packet with face obstruction image (mask cap and glare)",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Index. Other parameter details can be found in parameter in-line comments",
+			"Return Value": "Pre-requisite details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Environment and user details. Other parameters details can be found in-line",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data with obstruction face image",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$residentData=e2e_getResidentData(adult/*PERSONA_TYPE*/,false/*GUARDIAN_FLAG*/,Male,false/*LARGE_FACE*/,true/*OBSTRUCTED_FACE*/)"
+		},
+		"Step-5": {
+			"Description": "Generates packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated Template file path",
+			"Action": "$$template=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$residentData)"
+		},
+		"Step-6": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$rid=e2e_generateAndUploadPacketSkippingPrereg($$residentData,$$template)"
+		},
+		"Step-7": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$rid)"
+		},
+		"Step-8": {
+			"Description": "Deletes temporary data generated during packet creation including resident data packet templates and extra files to ensure a clean state for each E2E execution",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_DeletePacketData()"
+		}
+	},
+	{
 		"Scenario": "AFTER_SUITE",
 		"Tag": "Positive_Test",
 		"Persona": "ResidentMaleAdult",

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
@@ -200,6 +200,10 @@ public class PacketSyncService {
 			provider.addCondition(ResidentAttribute.RA_LargeFace,
 					Boolean.parseBoolean(props.get("LargeFace").toString()));
 		}
+		if (props.containsKey("ObstructedFace")) {
+			provider.addCondition(ResidentAttribute.RA_ObstructedFace,
+					Boolean.parseBoolean(props.get("ObstructedFace").toString()));
+		}
 		if (props.containsKey("Document")) {
 			provider.addCondition(ResidentAttribute.RA_Document,
 					Boolean.parseBoolean(props.get("Document").toString()));

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PhotoProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PhotoProvider.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 import javax.imageio.ImageIO;
 import java.awt.Graphics2D;
+import java.awt.Color;
+import java.awt.AlphaComposite;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,10 +27,14 @@ public class PhotoProvider {
 	static String Photo_File_Format = "/face%04d.jpg";
 
 	static byte[][] getPhoto(String contextKey) {
-		return getPhoto(contextKey, false);
+		return getPhoto(contextKey, false, false);
 	}
 
 	static byte[][] getPhoto(String contextKey, boolean generateLargeFace) {
+		return getPhoto(contextKey, generateLargeFace, false);
+	}
+
+	static byte[][] getPhoto(String contextKey, boolean generateLargeFace, boolean generateObstructedFace) {
 
 		byte[] bencoded = null;
 		byte[] bData = null;
@@ -101,6 +107,9 @@ public class PhotoProvider {
 				// compression handling.
 				img = upscaleImage(img, 8);
 			}
+			if (generateObstructedFace) {
+				img = applyFaceObstruction(img);
+			}
 			ImageIO.write(img, "jpg", baos);
 			baos.flush();
 			bData = baos.toByteArray();
@@ -129,6 +138,40 @@ public class PhotoProvider {
 		g2d.drawImage(source, 0, 0, enlarged.getWidth(), enlarged.getHeight(), null);
 		g2d.dispose();
 		return enlarged;
+	}
+
+	private static BufferedImage applyFaceObstruction(BufferedImage source) {
+		if (source == null) {
+			throw new IllegalArgumentException("source image must not be null");
+		}
+		int type = source.getType() == 0 ? BufferedImage.TYPE_INT_RGB : source.getType();
+		BufferedImage output = new BufferedImage(source.getWidth(), source.getHeight(), type);
+		Graphics2D g2d = output.createGraphics();
+		g2d.drawImage(source, 0, 0, null);
+
+		int width = output.getWidth();
+		int height = output.getHeight();
+
+		// Mask-like obstruction over lower half of face
+		g2d.setColor(new Color(28, 28, 28, 235));
+		int maskY = (int) (height * 0.58);
+		g2d.fillRoundRect((int) (width * 0.16), maskY, (int) (width * 0.68), (int) (height * 0.28), 30, 30);
+
+		// Cap-like obstruction over forehead
+		g2d.setColor(new Color(18, 18, 18, 245));
+		g2d.fillRoundRect((int) (width * 0.12), (int) (height * 0.02), (int) (width * 0.76), (int) (height * 0.24), 26,
+				26);
+		g2d.fillRect((int) (width * 0.20), (int) (height * 0.21), (int) (width * 0.60), (int) (height * 0.06));
+
+		// Glare-like streak on one eye area
+		g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.72f));
+		g2d.setColor(new Color(255, 255, 255));
+		g2d.fillOval((int) (width * 0.55), (int) (height * 0.28), (int) (width * 0.26), (int) (height * 0.12));
+		g2d.fillRoundRect((int) (width * 0.50), (int) (height * 0.34), (int) (width * 0.34), (int) (height * 0.04), 14,
+				14);
+
+		g2d.dispose();
+		return output;
 	}
 
 	static void splitImages(String contextKey) {

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/ResidentDataProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/ResidentDataProvider.java
@@ -520,8 +520,11 @@ public class ResidentDataProvider {
 			//	byte[][] faceData = PhotoProvider.getPhoto(idxes[i], res_gender.name(),contextKey );
 				Object largeFaceFlag = attributeList.get(ResidentAttribute.RA_LargeFace);
 				boolean generateLargeFace = largeFaceFlag != null && Boolean.parseBoolean(largeFaceFlag.toString());
+				Object obstructedFaceFlag = attributeList.get(ResidentAttribute.RA_ObstructedFace);
+				boolean generateObstructedFace = obstructedFaceFlag != null
+						&& Boolean.parseBoolean(obstructedFaceFlag.toString());
 				
-				byte[][] faceData = PhotoProvider.getPhoto(contextKey, generateLargeFace);
+				byte[][] faceData = PhotoProvider.getPhoto(contextKey, generateLargeFace, generateObstructedFace);
 				
 				bioData.setEncodedPhoto(
 						Base64.getEncoder().encodeToString(faceData[0]));

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/ResidentAttribute.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/ResidentAttribute.java
@@ -25,5 +25,6 @@ public enum ResidentAttribute {
 	RA_InvalidList,
 	RA_MissList,
 	RA_SCHEMA_VERSION,
-	RA_LargeFace
+	RA_LargeFace,
+	RA_ObstructedFace
 }


### PR DESCRIPTION
Resident walks to the center and creates a packet with face obstruction image (mask cap and glare)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating and processing resident data with obstructed face images
  * Implemented appointment slot expiration mechanism in the booking flow to manage slot availability
  * Extended face image generation to optionally apply visual obstructions for testing scenarios

* **Tests**
  * Added new test scenario to validate processing of residents with obstructed facial features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->