### PR TITLE
MOSIP-44816-Added new scnario

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/scenarios.json
@@ -32257,6 +32257,133 @@
 		}
 	},
 	{
+		"Scenario": "247",
+		"Tag": "Positive_Test",
+		"Persona": "ResidentMaleAdult",
+		"Group": "NA",
+		"Description": "Resident creates a Lost packet that gets rejected then reuses the same biometrics from the rejected Lost flow packet to create a new packet which gets processed successfully",
+		"Step-0": {
+			"Description": "Performs health check of given component",
+			"Input Parameters": "Keyword to check, only packetcreator is supported",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(packetcreator)"
+		},
+		"Step-1": {
+			"Description": "Reads the pre-requisite data at the given index",
+			"Input Parameters": "Index. Other parameter details can be found in parameter in-line comments",
+			"Return Value": "Pre-requisite details",
+			"Action": "$$details1=e2e_ReadPreReq(1/*PRE_REQUISITE_DATA_INDEX*/)"
+		},
+		"Step-2": {
+			"Description": "Sets the context for scenario execution",
+			"Input Parameters": "Environment and user details. Other details can be found in the parameter in-line comments",
+			"Return Value": "NA",
+			"Action": "e2e_setContext(env_context,$$details1,false/*GENERATE_PRIVATE_KEY*/)"
+		},
+		"Step-3": {
+			"Description": "Performs health check of required server components to run end-to-end scenarios",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_getPingHealth(targetenv)"
+		},
+		"Step-4": {
+			"Description": "Generates persona data",
+			"Input Parameters": "Details are in parameter in-line comments",
+			"Return Value": "Persona file path",
+			"Action": "$$personaFilePath=e2e_getResidentData(adult/*PERSONA_TYPE*/,false/*GUARDIAN_FLAG*/,Male)"
+		},
+		"Step-5": {
+			"Description": "Generates Lost packet template based on the persona data",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated template file path",
+			"Action": "$$lostTemplate=e2e_getPacketTemplate(LOST/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-6": {
+			"Description": "Creates Lost packet zip using the generated template",
+			"Input Parameters": "Packet type and Lost packet template path",
+			"Return Value": "Generated packet zip path",
+			"Action": "$$zipPacketPath=e2e_packetcreator(LOST/*PACKET_TYPE*/,$$lostTemplate)"
+		},
+		"Step-7": {
+			"Description": "Syncs Lost packet to get RID",
+			"Input Parameters": "Packet type and packet zip path",
+			"Return Value": "RID",
+			"Action": "$$ridLost=e2e_ridsync(LOST/*PACKET_TYPE*/,$$zipPacketPath)"
+		},
+		"Step-8": {
+			"Description": "Synchronizes the registration packet with the system using the provided ZIP packet path",
+			"Input Parameters": "ZIP packet path containing the registration packet data",
+			"Return Value": "Packet synchronization status or confirmation",
+			"Action": "e2e_packetsync($$zipPacketPath)"
+		},
+		"Step-9": {
+			"Description": "Sets manual verification status of Lost packet to rejected",
+			"Input Parameters": "RID and status",
+			"Return Value": "NA",
+			"Action": "e2e_postMockMv($$ridLost,REJECTED)"
+		},
+		"Step-10": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(REJECTED/*PACKET_STATUS*/,$$ridLost)"
+		},
+		"Step-11": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$ridLost,BIOGRAPHIC_VERIFICATION,FAILED)"
+		},
+		"Step-12": {
+			"Description": "Generates NEW packet template using the same persona so the same biometrics are reused",
+			"Input Parameters": "Process and persona file path",
+			"Return Value": "Generated template file path",
+			"Action": "$$templatePath=e2e_getPacketTemplate(NEW/*PACKET_TYPE*/,$$personaFilePath)"
+		},
+		"Step-13": {
+			"Description": "Generates and uploads packet with given persona and packet template skipping pre-registration step",
+			"Input Parameters": "Persona file path and template file path",
+			"Return Value": "RID",
+			"Action": "$$ridNew=e2e_generateAndUploadPacketSkippingPrereg($$personaFilePath,$$templatePath)"
+		},
+		"Step-14": {
+			"Description": "Checks the RID status against given packet processing status",
+			"Input Parameters": "Packet processing status and RID",
+			"Return Value": "NA",
+			"Action": "e2e_checkStatus(PROCESSED/*PACKET_STATUS*/,$$ridNew)"
+		},
+		"Step-15": {
+			"Description": "Gets the UIN for the given RID",
+			"Input Parameters": "RID",
+			"Return Value": "UIN",
+			"Action": "$$uin=e2e_getUINByRid($$ridNew)"
+		},
+		"Step-16": {
+			"Description": "Gets Email ID configured for the UIN",
+			"Input Parameters": "UIN",
+			"Return Value": "Email ID",
+			"Action": "$$email=e2e_getEmailByUIN($$uin)"
+		},
+		"Step-17": {
+			"Description": "Verifies notification is sent to resident for UIN generation",
+			"Input Parameters": "UIN and Email ID",
+			"Return Value": "NA",
+			"Action": "e2e_verifyNotification(UIN Generated,$$email)"
+		},
+		"Step-18": {
+			"Description": "Checks RID stage and stage status",
+			"Input Parameters": "RID, stage and stage status",
+			"Return Value": "NA",
+			"Action": "e2e_CheckRIDStage($$ridNew,PRINT_SERVICE,PROCESSED)"
+		},
+		"Step-19": {
+			"Description": "Deletes temporary data generated during packet creation including resident data packet templates and extra files to ensure a clean state for each E2E execution",
+			"Input Parameters": "NA",
+			"Return Value": "NA",
+			"Action": "e2e_DeletePacketData()"
+		}
+	},
+	{
 		"Scenario": "AFTER_SUITE",
 		"Tag": "Positive_Test",
 		"Persona": "ResidentMaleAdult",


### PR DESCRIPTION
Resident creates a Lost packet that gets rejected then reuses the same biometrics from the rejected Lost flow packet to create a new packet which gets processed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a new end-to-end validation scenario covering packet rejection handling, resubmission processing, and UIN generation notification workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/mosip-automation-tests/pull/951)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->