### PR TITLE
MOSIP-45020-Implement a centralized API logging mechanism that captures all internal API calls made from Packet Creator/Data Provider to backend services and prints them in the TestNG report.

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/BaseTestCaseUtil.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/BaseTestCaseUtil.java
@@ -24,6 +24,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Reporter;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.gson.Gson;
@@ -146,8 +147,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 	protected static String addContextToUrl(String url, Scenario.Step step) {
 
-		String scenarioId = step.getScenario().getId();
-		String context = System.getProperty("env.user") + "_S" + scenarioId + "_context";
+		String context = buildPacketCreatorContextKey(step.getScenario());
 
 		if (url.contains("?")) {
 			String urlArr[] = url.split("\\?");
@@ -156,6 +156,77 @@ public class BaseTestCaseUtil extends BaseStep {
 			return url;
 		else
 			return url + "/" + context;
+	}
+
+	/**
+	 * Context key segment appended to Packet Creator URLs (must match Packet
+	 * Creator / Data Provider namespace).
+	 */
+	public static String buildPacketCreatorContextKey(Scenario scenario) {
+		String scenarioId = scenario.getId();
+		return System.getProperty("env.user") + "_S" + scenarioId + "_context";
+	}
+
+	/**
+	 * After reporting a Packet Creator round-trip, fetch outbound internal API
+	 * traffic captured on the server for this scenario context and append it to
+	 * the TestNG report immediately under that call (when internal API logging is
+	 * enabled). Uses {@code clear=true} so each drain corresponds to traffic since
+	 * the previous drain for this context.
+	 */
+	public static void appendOutboundInternalApiLogsAfterPacketCreatorCall(Scenario.Step step, String resolvedUrl) {
+		if (!dslConfigManager.isInternalApiLoggingForReport() || step == null || resolvedUrl == null) {
+			return;
+		}
+		String pcBase = dslConfigManager.getpacketUtilityBaseUrl();
+		if (pcBase == null || pcBase.isEmpty() || !resolvedUrl.startsWith(pcBase)) {
+			return;
+		}
+		try {
+			String contextKey = buildPacketCreatorContextKey(step.getScenario());
+			String pathKey = java.net.URLEncoder.encode(contextKey, java.nio.charset.StandardCharsets.UTF_8)
+					.replace("+", "%20");
+			String logUrl = pcBase + "/context/internalApiLogs/" + pathKey + "?clear=true";
+			io.restassured.response.Response r = io.restassured.RestAssured.given().relaxedHTTPSValidation()
+					.get(logUrl);
+			String body;
+			if (r.getStatusCode() != 200) {
+				body = "Internal API log fetch failed: HTTP " + r.getStatusCode() + "\nURL: " + logUrl + "\nResponse: "
+						+ r.asString();
+			} else {
+				body = r.getBody().asString();
+				if (body == null) {
+					body = "";
+				}
+			}
+			if (r.getStatusCode() == 200 && (body.isBlank() || body.contains("no internal API calls recorded"))) {
+				return;
+			}
+			String escaped = org.testng.internal.Utils.escapeHtml(body);
+			StringBuilder block = new StringBuilder(512 + escaped.length());
+			block.append("<div class=\"dsl-internal-api-log\" style=\"margin:0.75em 0;\">");
+			block.append("<div style=\"font-weight:bold;margin-bottom:4px;\">");
+			block.append("Outbound internal API traffic (Packet Creator / Data Provider) for this call");
+			block.append("</div>");
+			// Grey bar — same visual role as main report &quot;Headers&quot; rows
+			block.append(
+					"<div style=\"border:solid 1px gray;background-color:lightgray;padding:4px 8px;font-weight:bold;\">");
+			block.append("Internal outbound calls (request + response per call)");
+			block.append("</div>");
+			// White bordered body — scroll capped so long JSON does not stretch the whole report
+			block.append("<div style=\"border:solid 1px gray;border-top:0;background-color:#fff;");
+			block.append("max-height:28em;overflow:auto;padding:8px;width:100%;box-sizing:border-box;\">");
+			block.append("<pre style=\"margin:0;white-space:pre-wrap;word-wrap:break-word;");
+			block.append("text-align:left;font-family:monospace;font-size:12px;line-height:1.25;\">");
+			block.append(escaped);
+			block.append("</pre></div></div>");
+			Reporter.log(block.toString(), false);
+		} catch (Exception e) {
+			logger.warn("Could not attach internal API log after packet creator call for context "
+					+ buildPacketCreatorContextKey(step.getScenario()), e);
+			Reporter.log("<pre>Internal API log error: " + org.testng.internal.Utils.escapeHtml(e.getMessage())
+					+ "</pre>", false);
+		}
 	}
 
 	public static Response getRequest(String url, String opsToLog, Scenario.Step step) {
@@ -171,6 +242,7 @@ public class BaseTestCaseUtil extends BaseStep {
 		}
 		GlobalMethods.ReportRequestAndResponse(null, getResponse.getHeaders().asList().toString(), url, null,
 				getResponse.getBody().asString(),true);
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return getResponse;
 	}
 	
@@ -204,6 +276,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, getResponse.getHeaders().asList().toString(), url, null,
 				getResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return getResponse;
 	}
 
@@ -214,6 +287,7 @@ public class BaseTestCaseUtil extends BaseStep {
 				MediaType.APPLICATION_JSON);
 		GlobalMethods.ReportRequestAndResponse(null, apiResponse.getHeaders().asList().toString(), url, body,
 				apiResponse.getBody().asString(),true);
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return apiResponse;
 	}
 
@@ -230,6 +304,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, puttResponse.getHeaders().asList().toString(), url, body,
 				puttResponse.asString(),true);
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 
 		return puttResponse;
 	}
@@ -247,6 +322,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, puttResponse.getHeaders().asList().toString(), url, body,
 				puttResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return puttResponse;
 	}
 
@@ -265,6 +341,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, putResponse.getHeaders().asList().toString(), url, null,
 				putResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return putResponse;
 	}
 
@@ -283,6 +360,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, deleteResponse.getHeaders().asList().toString(), url, null,
 				deleteResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 
 		return deleteResponse;
 	}
@@ -320,6 +398,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, deleteResponse.getHeaders().asList().toString(), url, null,
 				deleteResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 
 		return deleteResponse;
 	}
@@ -331,6 +410,7 @@ public class BaseTestCaseUtil extends BaseStep {
 				"*/*");
 		GlobalMethods.ReportRequestAndResponse(null, apiResponse.getHeaders().asList().toString(), url, body,
 				apiResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return apiResponse;
 	}
 
@@ -342,6 +422,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, apiResponse.getHeaders().asList().toString(), url, body,
 				apiResponse.asString(),true);
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return apiResponse;
 	}
 
@@ -359,6 +440,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, apiResponse.getHeaders().asList().toString(), url, body,
 				apiResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 
 		return apiResponse;
 	}
@@ -377,6 +459,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, postResponse.getHeaders().asList().toString(), url, body,
 				postResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 
 		return postResponse;
 	}
@@ -396,6 +479,7 @@ public class BaseTestCaseUtil extends BaseStep {
 
 		GlobalMethods.ReportRequestAndResponse(null, puttResponse.getHeaders().asList().toString(), url, null,
 				puttResponse.getBody().asString());
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return puttResponse;
 	}
 

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/BaseTestCaseUtil.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/BaseTestCaseUtil.java
@@ -41,6 +41,8 @@ import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.dslrig.ivv.core.base.BaseStep;
 import io.mosip.testrig.dslrig.ivv.core.dtos.Scenario;
 import io.mosip.testrig.dslrig.ivv.e2e.constant.E2EConstants;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
@@ -58,6 +60,11 @@ public class BaseTestCaseUtil extends BaseStep {
 
 	public static final long DEFAULT_WAIT_TIME = 30000l;
 	public static final long TIME_IN_MILLISEC = 1000l;
+
+	/** Max time to establish TCP connection when draining internal API logs from Packet Creator. */
+	private static final int INTERNAL_API_LOG_FETCH_CONNECT_MS = 10_000;
+	/** Max time to read response body for internal API log drain (large captured payloads). */
+	private static final int INTERNAL_API_LOG_FETCH_READ_MS = 30_000;
 
 	public static PacketUtility packetUtility = new PacketUtility();
 	public static Hashtable<String, Map<String, String>> hashtable = new Hashtable<>();
@@ -187,8 +194,12 @@ public class BaseTestCaseUtil extends BaseStep {
 			String pathKey = java.net.URLEncoder.encode(contextKey, java.nio.charset.StandardCharsets.UTF_8)
 					.replace("+", "%20");
 			String logUrl = pcBase + "/context/internalApiLogs/" + pathKey + "?clear=true";
-			io.restassured.response.Response r = io.restassured.RestAssured.given().relaxedHTTPSValidation()
-					.get(logUrl);
+			RestAssuredConfig timeoutConfig = RestAssuredConfig.config()
+					.httpClient(HttpClientConfig.httpClientConfig()
+							.setParam("http.connection.timeout", INTERNAL_API_LOG_FETCH_CONNECT_MS)
+							.setParam("http.socket.timeout", INTERNAL_API_LOG_FETCH_READ_MS));
+			io.restassured.response.Response r = io.restassured.RestAssured.given().config(timeoutConfig)
+					.relaxedHTTPSValidation().get(logUrl);
 			String body;
 			if (r.getStatusCode() != 200) {
 				body = "Internal API log fetch failed: HTTP " + r.getStatusCode() + "\nURL: " + logUrl + "\nResponse: "

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/PacketUtility.java
@@ -745,6 +745,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 		String url = this.baseUrl + "/servercontext/" + key;
 
 		JSONObject jsonReq = new JSONObject();
+		jsonReq.put("internalApiLogging", dslConfigManager.getInternalApiLoggingForContextProps());
 		jsonReq.put(URLBASE, baseUrl);
 		jsonReq.put(MOSIP_TEST_BASEURL, baseUrl);
 		jsonReq.put(MOSIP_TEST_REGCLIENT_MACHINEID, E2EConstants.MACHINE_ID);
@@ -782,6 +783,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 		}
 		JSONObject jsonReq = new JSONObject();
 		jsonReq.put("enableDebug", dslConfigManager.getEnableDebug());
+		jsonReq.put("internalApiLogging", dslConfigManager.getInternalApiLoggingForContextProps());
 		logger.info("Running suite with enableDebug : " + dslConfigManager.getEnableDebug());
 		jsonReq.put("baselang", BaseTestCase.getLanguageList().get(0));
 
@@ -890,6 +892,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 		jsonReq.put("consent", consent);
 		jsonReq.put("invalidCertFlag", invalidCertFlag);
 		jsonReq.put("enableDebug", dslConfigManager.getEnableDebug());
+		jsonReq.put("internalApiLogging", dslConfigManager.getInternalApiLoggingForContextProps());
 		jsonReq.put("eSignetbaseurl", ConfigManager.getEsignetBaseUrl());
 		logger.info("Running suite with enableDebug : " + dslConfigManager.getEnableDebug());
 		jsonReq.put(URLBASE, envbaseUrl);
@@ -1380,11 +1383,9 @@ public class PacketUtility extends BaseTestCaseUtil {
 			getResponse = given().relaxedHTTPSValidation().accept("*/*").contentType("application/json").when()
 					.body(body).get(url).then().extract().response();
 		}
-		/*
-		 * GlobalMethods.ReportRequestAndResponse(null,
-		 * getResponse.getHeaders().asList().toString(), url, body,
-		 * getResponse.asString(),true);
-		 */
+		GlobalMethods.ReportRequestAndResponse(null, getResponse.getHeaders().asList().toString(), url, body,
+				getResponse.getBody().asString(), true);
+		appendOutboundInternalApiLogsAfterPacketCreatorCall(step, url);
 		return getResponse;
 	}
 
@@ -1509,6 +1510,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 
 		GlobalMethods.ReportRequestAndResponse("", "", url, body, puttResponse.getBody().asString());
 
+
 		return puttResponse;
 	}
 
@@ -1524,6 +1526,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 		}
 
 		GlobalMethods.ReportRequestAndResponse("", "", url, body, posttResponse.getBody().asString());
+
 
 		return posttResponse;
 	}
@@ -1657,6 +1660,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 	public Response getRequestWithCookiesAndPathParam(String url, String token, String opsToLog) {
 		Response getResponse = given().relaxedHTTPSValidation().cookie(AUTHORIZATION, token).log().all().when().get(url)
 				.then().log().all().extract().response();
+
 
 		return getResponse;
 	}
@@ -1812,6 +1816,7 @@ public class PacketUtility extends BaseTestCaseUtil {
 					.cookie(AUTHORIZATION, token).put(url).then().extract().response();
 		}
 		GlobalMethods.ReportRequestAndResponse("", "", url, "", puttResponse.getBody().asString());
+
 
 		return puttResponse;
 	}

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/dslConfigManager.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/dslConfigManager.java
@@ -189,4 +189,26 @@ public class dslConfigManager extends ConfigManager {
 
 		return properties;
 	}
+
+	/**
+	 * When true, the IVV orchestrator pulls outbound Packet Creator API traces after
+	 * each scenario and attaches them to the TestNG report (requires the same flag /
+	 * context variables on Packet Creator so calls are captured).
+	 */
+	public static boolean isInternalApiLoggingForReport() {
+		if (Boolean.parseBoolean(System.getProperty("dslrig.internal.api.logging", "false"))) {
+			return true;
+		}
+		try {
+			String v = ConfigManager.getproperty("internalApiLogging");
+			return v != null && "yes".equalsIgnoreCase(v.trim());
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	/** Value stored on Packet Creator context so {@link io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogging} enables capture. */
+	public static String getInternalApiLoggingForContextProps() {
+		return isInternalApiLoggingForReport() ? "yes" : "no";
+	}
 }

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/resources/config/dsl.properties
@@ -56,6 +56,8 @@ nextPacketUploadWaitTime=
 esignetActuatorPropertySection=esignet-default.properties
 checkNotification=yes
 enableDebug=yes
+# yes = capture outbound MOSIP API traffic inside Packet Creator/Data Provider and attach to TestNG report (orchestrator pulls logs after each scenario)
+internalApiLogging=yes
 maxSuiteTime=2
 roles=GLOBAL_ADMIN,ID_AUTHENTICATION,REGISTRATION_ADMIN,REGISTRATION_SUPERVISOR,ZONAL_ADMIN,AUTH_PARTNER,PARTNER_ADMIN,PMS_ADMIN,POLICYMANAGER,REGISTRATION_SUPERVISOR,DATA_READ,uma_authorization
 

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/ContextController.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/ContextController.java
@@ -1,5 +1,6 @@
 package io.mosip.testrig.dslrig.packetcreator.controller;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -8,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +21,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.mosip.testrig.dslrig.dataprovider.util.DataProviderConstants;
 import io.mosip.testrig.dslrig.dataprovider.util.ServiceException;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogCollector;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogExchange;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogFormatter;
 import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
 import io.mosip.testrig.dslrig.packetcreator.service.CommandsService;
 import io.mosip.testrig.dslrig.packetcreator.service.ContextUtils;
@@ -135,4 +140,14 @@ public class ContextController {
 
         }
     }
+
+	@Operation(summary = "Retrieve formatted internal (outbound) API log for a context", description = "Used by the DSL orchestrator to attach outbound MOSIP traffic to TestNG reports. "
+			+ "Does not log inbound DSL calls to Packet Creator.")
+	@GetMapping(value = "/context/internalApiLogs/{contextKey}", produces = MediaType.TEXT_PLAIN_VALUE)
+	public @ResponseBody String getInternalApiLogs(@PathVariable("contextKey") String contextKey,
+			@RequestParam(name = "clear", defaultValue = "true") boolean clear) {
+		List<InternalApiLogExchange> list = clear ? InternalApiLogCollector.drain(contextKey)
+				: InternalApiLogCollector.snapshot(contextKey);
+		return InternalApiLogFormatter.format(list);
+	}
 }

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/ContextController.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/ContextController.java
@@ -1,153 +1,153 @@
-package io.mosip.testrig.dslrig.packetcreator.controller;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
-
-import io.mosip.testrig.dslrig.dataprovider.util.DataProviderConstants;
-import io.mosip.testrig.dslrig.dataprovider.util.ServiceException;
-import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogCollector;
-import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogExchange;
-import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogFormatter;
-import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
-import io.mosip.testrig.dslrig.packetcreator.service.CommandsService;
-import io.mosip.testrig.dslrig.packetcreator.service.ContextUtils;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-@RestController
-@Tag(name = "ContextController", description = "REST APIs for context management")
-public class ContextController {
-
-	@Autowired
-	ContextUtils contextUtils;
-	@Value("${mosip.test.persona.configpath}")
-	private String personaConfigPath;
-
-	@Autowired
-	CommandsService commandsService;
-
-	private static final Logger logger = LoggerFactory.getLogger(ContextController.class);
-
-	@Operation(summary = "Initialize the server context")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Successfully created the server context") })
-	@PostMapping(value = "/context/server/{contextKey}")
-	public ResponseEntity<?> createServerContext(@RequestBody Properties contextProperties,
-	                                             @PathVariable("contextKey") String contextKey) {
-
-	    logger.info("-------------------- Scenario : " 
-	                + contextProperties.getProperty("scenario")
-	                + " --------------------");
-
-	    try {
-	        if (personaConfigPath != null && !personaConfigPath.isEmpty()) {
-	            DataProviderConstants.RESOURCE = personaConfigPath;
-	        }
-
-	        String result = contextUtils.createUpdateServerContext(contextProperties, contextKey);
-
-	        return ResponseEntity.ok(
-	                Map.of(
-	                    "success", result,
-	                    "context", contextKey,
-	                    "message", "Server context created"
-	                )
-	        );
-
-	    } catch (ServiceException se) {
-	        throw se; // let global exception handler process it
-	    } catch (Exception ex) {
-	        logger.error("createServerContext", ex);
-			throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "CREATE_SERVER_CONTEXT_FAIL", null, ex);
-	    }
-	}
-
-
-
-	@GetMapping("/ping/{eSignetDeployed}/{contextKey}")
-
-	@Operation(summary = "Verify target environment", description = "Verify if the target environment (context) is available.", responses = {
-
-			@ApiResponse(responseCode = "200", description = "Target environment verified successfully") })
-	public @ResponseBody String checkContext(@RequestParam(name = "module", required = false) String module,
-
-			@PathVariable String eSignetDeployed, @PathVariable("contextKey") String contextKey) {
-
-		try {
-
-			return commandsService.checkContext(contextKey, module, eSignetDeployed);
-
-		} catch (ServiceException se) {
-            throw se; // let global exception handler process it
-        } catch (Exception ex) {
-            logger.error("checkContext", ex);
-			throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "CHECK_CONTEXT_FAIL", null, ex);
-        }
-    }
-
-    @Operation(summary = "Retrieve the server context")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved the server context") })
-    @GetMapping(value = "/context/server/{contextKey}")
-    public @ResponseBody Properties getServerContext(@PathVariable("contextKey") String contextKey) {
-        Properties bRet = null;
-        try {
-            bRet = contextUtils.loadServerContext(contextKey);
-        }  catch (ServiceException se) {
-            throw se; // let global exception handler process it
-        } catch (Exception ex) {
-            logger.error("getServerContext", ex);
-            throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "GET_SERVER_CONTEXT_FAIL", null, ex);
-        }
-        return bRet;
-    }
-
-    @Operation(summary = "Reset the server context data")
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Context data reset successfully") })
-    @GetMapping(value = "/resetContextData/{contextKey}")
-    public @ResponseBody String resetContextData(@PathVariable("contextKey") String contextKey) {
-		try {
-			Object urlBase = VariableManager.getVariableValue(contextKey, "urlBase");
-			ContextUtils.clearPacketGenFolders(contextKey);
-			VariableManager.deleteNameSpace(contextKey);
-			if (urlBase != null) {
-				VariableManager.deleteNameSpace(urlBase.toString() + "run_context");
-			}
-			return "true";
-		} catch (ServiceException se) {
-            throw se; // let global exception handler process it
-        } catch (Exception ex) {
-            logger.error("resetContextData", ex);
-            throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "RESET_CONTEXT_FAIL", null, ex);
-
-        }
-    }
-
-	@Operation(summary = "Retrieve formatted internal (outbound) API log for a context", description = "Used by the DSL orchestrator to attach outbound MOSIP traffic to TestNG reports. "
-			+ "Does not log inbound DSL calls to Packet Creator.")
-	@GetMapping(value = "/context/internalApiLogs/{contextKey}", produces = MediaType.TEXT_PLAIN_VALUE)
-	public @ResponseBody String getInternalApiLogs(@PathVariable("contextKey") String contextKey,
-			@RequestParam(name = "clear", defaultValue = "true") boolean clear) {
-		List<InternalApiLogExchange> list = clear ? InternalApiLogCollector.drain(contextKey)
-				: InternalApiLogCollector.snapshot(contextKey);
-		return InternalApiLogFormatter.format(list);
-	}
-}
+package io.mosip.testrig.dslrig.packetcreator.controller;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.mosip.testrig.dslrig.dataprovider.util.DataProviderConstants;
+import io.mosip.testrig.dslrig.dataprovider.util.ServiceException;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogCollector;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogExchange;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogFormatter;
+import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
+import io.mosip.testrig.dslrig.packetcreator.service.CommandsService;
+import io.mosip.testrig.dslrig.packetcreator.service.ContextUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@Tag(name = "ContextController", description = "REST APIs for context management")
+public class ContextController {
+
+	@Autowired
+	ContextUtils contextUtils;
+	@Value("${mosip.test.persona.configpath}")
+	private String personaConfigPath;
+
+	@Autowired
+	CommandsService commandsService;
+
+	private static final Logger logger = LoggerFactory.getLogger(ContextController.class);
+
+	@Operation(summary = "Initialize the server context")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Successfully created the server context") })
+	@PostMapping(value = "/context/server/{contextKey}")
+	public ResponseEntity<?> createServerContext(@RequestBody Properties contextProperties,
+	                                             @PathVariable("contextKey") String contextKey) {
+
+	    logger.info("-------------------- Scenario : " 
+	                + contextProperties.getProperty("scenario")
+	                + " --------------------");
+
+	    try {
+	        if (personaConfigPath != null && !personaConfigPath.isEmpty()) {
+	            DataProviderConstants.RESOURCE = personaConfigPath;
+	        }
+
+	        String result = contextUtils.createUpdateServerContext(contextProperties, contextKey);
+
+	        return ResponseEntity.ok(
+	                Map.of(
+	                    "success", result,
+	                    "context", contextKey,
+	                    "message", "Server context created"
+	                )
+	        );
+
+	    } catch (ServiceException se) {
+	        throw se; // let global exception handler process it
+	    } catch (Exception ex) {
+	        logger.error("createServerContext", ex);
+			throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "CREATE_SERVER_CONTEXT_FAIL", null, ex);
+	    }
+	}
+
+
+
+	@GetMapping("/ping/{eSignetDeployed}/{contextKey}")
+
+	@Operation(summary = "Verify target environment", description = "Verify if the target environment (context) is available.", responses = {
+
+			@ApiResponse(responseCode = "200", description = "Target environment verified successfully") })
+	public @ResponseBody String checkContext(@RequestParam(name = "module", required = false) String module,
+
+			@PathVariable String eSignetDeployed, @PathVariable("contextKey") String contextKey) {
+
+		try {
+
+			return commandsService.checkContext(contextKey, module, eSignetDeployed);
+
+		} catch (ServiceException se) {
+            throw se; // let global exception handler process it
+        } catch (Exception ex) {
+            logger.error("checkContext", ex);
+			throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "CHECK_CONTEXT_FAIL", null, ex);
+        }
+    }
+
+    @Operation(summary = "Retrieve the server context")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved the server context") })
+    @GetMapping(value = "/context/server/{contextKey}")
+    public @ResponseBody Properties getServerContext(@PathVariable("contextKey") String contextKey) {
+        Properties bRet = null;
+        try {
+            bRet = contextUtils.loadServerContext(contextKey);
+        }  catch (ServiceException se) {
+            throw se; // let global exception handler process it
+        } catch (Exception ex) {
+            logger.error("getServerContext", ex);
+            throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "GET_SERVER_CONTEXT_FAIL", null, ex);
+        }
+        return bRet;
+    }
+
+    @Operation(summary = "Reset the server context data")
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Context data reset successfully") })
+    @GetMapping(value = "/resetContextData/{contextKey}")
+    public @ResponseBody String resetContextData(@PathVariable("contextKey") String contextKey) {
+		try {
+			Object urlBase = VariableManager.getVariableValue(contextKey, "urlBase");
+			ContextUtils.clearPacketGenFolders(contextKey);
+			VariableManager.deleteNameSpace(contextKey);
+			if (urlBase != null) {
+				VariableManager.deleteNameSpace(urlBase.toString() + "run_context");
+			}
+			return "true";
+		} catch (ServiceException se) {
+            throw se; // let global exception handler process it
+        } catch (Exception ex) {
+            logger.error("resetContextData", ex);
+            throw new ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "RESET_CONTEXT_FAIL", null, ex);
+
+        }
+    }
+
+	@Operation(summary = "Retrieve formatted internal (outbound) API log for a context", description = "Used by the DSL orchestrator to attach outbound MOSIP traffic to TestNG reports. "
+			+ "Does not log inbound DSL calls to Packet Creator.")
+	@GetMapping(value = "/context/internalApiLogs/{contextKey}", produces = MediaType.TEXT_PLAIN_VALUE)
+	public @ResponseBody String getInternalApiLogs(@PathVariable("contextKey") String contextKey,
+			@RequestParam(name = "clear", defaultValue = "true") boolean clear) {
+		List<InternalApiLogExchange> list = clear ? InternalApiLogCollector.drain(contextKey)
+				: InternalApiLogCollector.snapshot(contextKey);
+		return InternalApiLogFormatter.format(list);
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
@@ -34,6 +34,9 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import io.mosip.testrig.dslrig.dataprovider.mds.HttpRCapture;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogging;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiManualRecorder;
+import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiRestAssuredFilter;
 import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -76,6 +79,15 @@ public class RestClient {
 		// RestAssured.filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
 
 	}
+
+	private static RequestSpecification givenFiltered(String contextKey) {
+		RequestSpecification spec = given();
+		if (InternalApiLogging.isEnabled(contextKey)) {
+			spec = spec.filter(new InternalApiRestAssuredFilter(contextKey));
+		}
+		return spec;
+	}
+
 	String _urlBase;
 
 	int http_status;
@@ -180,10 +192,10 @@ public class RestClient {
 				Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 				if (isDebugEnabled(contextKey)) {
-					response = given().log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+					response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 							.get(url, mapPathParam).then().log().all().extract().response();
 				} else {
-					response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+					response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 							mapPathParam);
 				}
 				if (response.getStatusCode() == 401) {
@@ -254,10 +266,10 @@ public class RestClient {
 				Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 				if (isDebugEnabled(contextKey)) {
-					response = given().log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+					response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 							.get(url, mapPathParam).then().log().all().extract().response();
 				} else {
-					response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+					response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 							mapPathParam);
 				}
 
@@ -312,10 +324,10 @@ public class RestClient {
 				Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 				if (isDebugEnabled(contextKey)) {
-					response = given().log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+					response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 							.get(url, mapPathParam).then().log().all().extract().response();
 				} else {
-					response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+					response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 							mapPathParam);
 				}
 
@@ -363,7 +375,7 @@ public class RestClient {
 
 		Response response = null;
 		try {
-			response = given()
+			response = givenFiltered(null)
 					.relaxedHTTPSValidation()
 					.log().all()
 					.when()
@@ -393,10 +405,10 @@ public class RestClient {
 			Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 			if (isDebugEnabled(contextKey)) {
-				response = given().log().all().contentType(ContentType.JSON).queryParams(mapParam)
+				response = givenFiltered(contextKey).log().all().contentType(ContentType.JSON).queryParams(mapParam)
 						.get(url, mapPathParam).then().log().all().extract().response();
 			} else {
-				response = given().contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
+				response = givenFiltered(contextKey).contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
 			}
 
 			if (isDebugEnabled(contextKey) && response != null) {
@@ -450,10 +462,10 @@ public class RestClient {
 			Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 			if (isDebugEnabled(contextKey)) {
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 						.get(url, mapPathParam).then().log().all().extract().response();
 			} else {
-				response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 						mapPathParam);
 			}
 
@@ -503,10 +515,10 @@ public class RestClient {
 		Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 		if (isDebugEnabled(contextKey)) {
-			response = given().log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 					.get(url, mapPathParam).then().log().all().extract().response();
 		} else {
-			response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
+			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
 		}
 
 		if (isDebugEnabled(contextKey) && response != null) {
@@ -544,18 +556,18 @@ public class RestClient {
 
 		if (requestData != null) {
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().cookie(kukki).multiPart("file", new File(filePath))
+				response = givenFiltered(contextKey).log().all().cookie(kukki).multiPart("file", new File(filePath))
 						.param("Document request", requestData.toString()).post(url).then().log().all().extract()
 						.response();
 			else
-				response = given().cookie(kukki).multiPart("file", new File(filePath))
+				response = givenFiltered(contextKey).cookie(kukki).multiPart("file", new File(filePath))
 						.param("Document request", requestData.toString()).post(url);
 		} else {
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().cookie(kukki).multiPart("file", new File(filePath)).post(url).then()
+				response = givenFiltered(contextKey).log().all().cookie(kukki).multiPart("file", new File(filePath)).post(url).then()
 						.log().all().extract().response();
 			else
-				response = given().cookie(kukki).multiPart("file", new File(filePath)).post(url);
+				response = givenFiltered(contextKey).cookie(kukki).multiPart("file", new File(filePath)).post(url);
 		}
 		if (response == null) {
 			throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
@@ -587,9 +599,9 @@ public class RestClient {
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			spec = given().log().all().cookie(kukki);
+			spec = givenFiltered(contextKey).log().all().cookie(kukki);
 		else
-			spec = given().cookie(kukki);
+			spec = givenFiltered(contextKey).cookie(kukki);
 		for (String fName : filePaths)
 			spec = spec.multiPart("files", new File(fName));
 		if (requestData != null) {
@@ -642,10 +654,10 @@ public class RestClient {
 		logInfo(contextKey, "Request: " + jsonRequest.toString());
 		try {
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().contentType(ContentType.JSON).body(jsonRequest.toString()).post(url)
+				response = givenFiltered(contextKey).log().all().contentType(ContentType.JSON).body(jsonRequest.toString()).post(url)
 						.then().log().all().extract().response();
 			else
-				response = given().contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
+				response = givenFiltered(contextKey).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
 		} catch (ServiceException se) {
 			throw se;
 		} catch (Exception e) {
@@ -696,10 +708,10 @@ public class RestClient {
 		try {
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.post(url).then().log().all().extract().response();
 			else
-				response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
 
 			if (isDebugEnabled(contextKey)) {
 				if (response != null) {
@@ -756,10 +768,10 @@ public class RestClient {
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.put(url).then().log().all().extract().response();
 		else
-			response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
@@ -787,10 +799,10 @@ public class RestClient {
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
+			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
@@ -817,10 +829,10 @@ public class RestClient {
 		logInfo(contextKey, "Request:" + jsonRequest.toString());
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 		if (isDebugEnabled(contextKey))
-			response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
+			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 			token = cookie.split("=")[1];
@@ -845,10 +857,10 @@ public class RestClient {
 		logInfo(contextKey, "Request:" + jsonRequest.toString());
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 		if (isDebugEnabled(contextKey))
-			response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
+			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 			token = cookie.split("=")[1];
@@ -875,10 +887,10 @@ public class RestClient {
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			response = given().log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap())
+			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap()).delete(url);
+			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap()).delete(url);
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
@@ -899,10 +911,10 @@ public class RestClient {
 	public static Response post(String url, String requestBody, String contextKey) throws Exception {
 		Response response = null;
 		if (isDebugEnabled(contextKey))
-			response = RestAssured.given().log().all().baseUri(url).contentType(ContentType.JSON).and()
+			response = givenFiltered(contextKey).log().all().baseUri(url).contentType(ContentType.JSON).and()
 					.body(requestBody).when().post().then().log().all().extract().response();
 		else
-			response = RestAssured.given().baseUri(url).contentType(ContentType.JSON).and().body(requestBody).when()
+			response = givenFiltered(contextKey).baseUri(url).contentType(ContentType.JSON).and().body(requestBody).when()
 					.post().then().extract().response();
 
 		return response;
@@ -933,10 +945,10 @@ public class RestClient {
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.post(url).then().log().all().extract().response();
 			else
-				response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -998,10 +1010,10 @@ public class RestClient {
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey)) {
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.put(url).then().log().all().extract().response();
 			} else
-				response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1079,10 +1091,10 @@ public class RestClient {
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey)) {
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.put(url).then().log().all().extract().response();
 			} else
-				response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1126,10 +1138,10 @@ public class RestClient {
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey)) {
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.put(url).then().log().all().extract().response();
 			} else
-				response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1173,10 +1185,10 @@ public class RestClient {
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.patch(url).then().log().all().extract().response();
 			else
-				response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).patch(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).patch(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1214,10 +1226,10 @@ public class RestClient {
 			Response response = null;
 			try {
 				if (isDebugEnabled(contextKey))
-					response = given().log().all().contentType("application/json").body(jsonBody).post(url).then().log()
+					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(url).then().log()
 							.all().extract().response();
 				else
-					response = given().contentType("application/json").body(jsonBody).post(url);
+					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(url);
 			} catch (Exception e) {
 				logger.error(e.getMessage());
 			}
@@ -1266,10 +1278,10 @@ public class RestClient {
 			Response response = null;
 			try {
 				if (isDebugEnabled(contextKey))
-					response = given().log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
+					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
 							.log().all().extract().response();
 				else
-					response = given().contentType("application/json").body(jsonBody).post(authUrl);
+					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
 			} catch (Exception e) {
 				logger.error(e.getMessage());
 			}
@@ -1325,10 +1337,10 @@ public class RestClient {
 			Response response = null;
 			try {
 				if (isDebugEnabled(contextKey))
-					response = given().log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
+					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
 							.log().all().extract().response();
 				else
-					response = given().contentType("application/json").body(jsonBody).post(authUrl);
+					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
 
 			} catch (Exception e) {
 				logger.error(e.getMessage());
@@ -1384,10 +1396,10 @@ public class RestClient {
 			Response response = null;
 			try {
 				if (isDebugEnabled(contextKey))
-					response = given().log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
+					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
 							.log().all().extract().response();
 				else
-					response = given().contentType("application/json").body(jsonBody).post(authUrl);
+					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
 			} catch (Exception e) {
 				logger.error(e.getMessage());
 			}
@@ -1439,10 +1451,10 @@ public class RestClient {
 			Response response = null;
 			try {
 				if (isDebugEnabled(contextKey))
-					response = given().log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
+					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
 							.log().all().extract().response();
 				else
-					response = given().contentType("application/json").body(jsonBody).post(authUrl);
+					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
 			} catch (Exception e) {
 				logger.error(e.getMessage());
 			}
@@ -1495,10 +1507,10 @@ public class RestClient {
 			Response response = null;
 			try {
 				if (isDebugEnabled(contextKey))
-					response = given().log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
+					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
 							.log().all().extract().response();
 				else
-					response = given().contentType("application/json").body(jsonBody).post(authUrl);
+					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
 			} catch (Exception e) {
 				logger.error(e.getMessage());
 			}
@@ -1607,6 +1619,14 @@ public class RestClient {
 				// TODO: handle exception
 			}
 		}
+		if (InternalApiLogging.isEnabled(null)) {
+			StringBuilder reqH = new StringBuilder();
+			reqH.append("Content-Type: application/json\nAccept: application/json\n");
+			headers.forEach((k, v) -> reqH.append(k.toString()).append(": ").append(v.toString()).append('\n'));
+			String rh = String.valueOf(conn.getHeaderFields());
+			InternalApiManualRecorder.record(null, "GET", strUrl, reqH.toString(), "", http_status, rh,
+					builder.toString());
+		}
 		return builder.toString();
 	}
 
@@ -1630,11 +1650,11 @@ public class RestClient {
 			Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 						.get(url, mapPathParam).then().log().all().extract().response();
 
 			else
-				response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 						mapPathParam);
 
 			if (response.getStatusCode() == 401) {
@@ -1657,15 +1677,36 @@ public class RestClient {
 
 	public static String rawHttp(HttpRCapture httpRCapture, String jsonBody, String contextKey) throws IOException {
 
+		String uriStr = httpRCapture.getURI() != null ? httpRCapture.getURI().toString() : "";
+		String method = httpRCapture.getMethod() != null ? httpRCapture.getMethod() : "POST";
+		StringBuilder reqHeaders = new StringBuilder();
+		try {
+			for (org.apache.http.Header h : httpRCapture.getAllHeaders()) {
+				reqHeaders.append(h.getName()).append(": ").append(h.getValue()).append('\n');
+			}
+		} catch (Exception ignored) {
+		}
+
 		String result = "";
 		try (CloseableHttpClient httpClient = HttpClients.createDefault();) {
 			httpRCapture.setEntity(new StringEntity(jsonBody));
 			HttpResponse response = httpClient.execute(httpRCapture);
+			int code = response.getStatusLine().getStatusCode();
+			StringBuilder respHeaders = new StringBuilder();
+			for (org.apache.http.Header h : response.getAllHeaders()) {
+				respHeaders.append(h.getName()).append(": ").append(h.getValue()).append('\n');
+			}
 			HttpEntity entity = response.getEntity();
 			if (entity != null) {
 				result = EntityUtils.toString(entity);
 				logInfo(contextKey, result);
 			}
+			InternalApiManualRecorder.record(contextKey, method, uriStr, reqHeaders.toString(), jsonBody, code,
+					respHeaders.toString(), result);
+		} catch (IOException e) {
+			InternalApiManualRecorder.recordFailure(contextKey, method, uriStr, reqHeaders.toString(), jsonBody,
+					e.getMessage());
+			throw e;
 		}
 		return result;
 	}
@@ -1688,10 +1729,10 @@ public class RestClient {
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			if (isDebugEnabled(contextKey))
-				response = given().log().all().cookie(kukki).contentType(ContentType.JSON).get(url).then().log().all()
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).get(url).then().log().all()
 						.extract().response();
 			else
-				response = given().cookie(kukki).contentType(ContentType.JSON).get(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).get(url);
 
 			if (response.getStatusCode() == 401) {
 				if (nLoop >= 1)
@@ -1724,10 +1765,10 @@ public class RestClient {
 
 		Response response = null;
 		if (isDebugEnabled(contextKey))
-			response = given().log().all().contentType(ContentType.JSON).get(urlAct).then().log().all().extract()
+			response = givenFiltered(contextKey).log().all().contentType(ContentType.JSON).get(urlAct).then().log().all().extract()
 					.response();
 		else
-			response = given().contentType(ContentType.JSON).get(urlAct);
+			response = givenFiltered(contextKey).contentType(ContentType.JSON).get(urlAct);
 
 		if (response != null && response.getStatusCode() == 200) {
 			checkErrorResponse(response.getBody().asString(), urlAct);

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
@@ -1729,10 +1729,10 @@ public class RestClient {
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).get(url).then().log().all()
+				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).get(urlAct).then().log().all()
 						.extract().response();
 			else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).get(url);
+				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).get(urlAct);
 
 			if (response.getStatusCode() == 401) {
 				if (nLoop >= 1)

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogCollector.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogCollector.java
@@ -2,21 +2,71 @@ package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * In-memory store of outbound API exchanges, keyed by Packet Creator /
- * Data Provider context id.
+ * In-memory store of outbound API exchanges, keyed by Packet Creator / Data
+ * Provider context id.
+ * <p>
+ * <strong>Cleanup contract:</strong> Callers that own a context should invoke
+ * {@link #drain(String)} or {@link #clear(String)} when logs are no longer
+ * needed so memory is reclaimed immediately. In addition, each context bucket is
+ * dropped automatically if it has had no activity (no new {@link #record} and no
+ * {@link #snapshot} read) for 12 hours, so long-running suites do not retain
+ * stale context keys indefinitely.
  */
 public final class InternalApiLogCollector {
 
+	private static final int CONTEXT_TTL_HOURS = 12;
+	private static final long CONTEXT_TTL_MILLIS = TimeUnit.HOURS.toMillis(CONTEXT_TTL_HOURS);
+	private static final long CLEANUP_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(1);
+
 	private static final AtomicLong SEQ = new AtomicLong(1L);
-	private static final Map<String, List<InternalApiLogExchange>> BY_CONTEXT = new ConcurrentHashMap<>();
+	private static final Map<String, ContextBucket> BY_CONTEXT = new ConcurrentHashMap<>();
+	private static volatile long lastCleanupMillis;
 
 	private InternalApiLogCollector() {
+	}
+
+	private static final class ContextBucket {
+		volatile long lastActivityMillis;
+		final List<InternalApiLogExchange> entries = Collections.synchronizedList(new ArrayList<>());
+
+		ContextBucket() {
+			lastActivityMillis = System.currentTimeMillis();
+		}
+
+		void touch() {
+			lastActivityMillis = System.currentTimeMillis();
+		}
+	}
+
+	/**
+	 * Removes context buckets whose last activity is older than 12 hours. Scans
+	 * are throttled to roughly once per minute.
+	 */
+	private static void maybeExpireStaleContexts() {
+		long now = System.currentTimeMillis();
+		if (now - lastCleanupMillis < CLEANUP_INTERVAL_MILLIS) {
+			return;
+		}
+		synchronized (InternalApiLogCollector.class) {
+			if (now - lastCleanupMillis < CLEANUP_INTERVAL_MILLIS) {
+				return;
+			}
+			lastCleanupMillis = now;
+			for (Iterator<Map.Entry<String, ContextBucket>> it = BY_CONTEXT.entrySet().iterator(); it.hasNext();) {
+				Map.Entry<String, ContextBucket> e = it.next();
+				if (now - e.getValue().lastActivityMillis >= CONTEXT_TTL_MILLIS) {
+					it.remove();
+				}
+			}
+		}
 	}
 
 	public static long nextSequence() {
@@ -30,23 +80,28 @@ public final class InternalApiLogCollector {
 		if (exchange == null) {
 			return;
 		}
+		maybeExpireStaleContexts();
 		String key = contextKey == null || contextKey.isBlank() ? GLOBAL_LOG_KEY : contextKey;
-		BY_CONTEXT.computeIfAbsent(key, k -> Collections.synchronizedList(new ArrayList<>())).add(exchange);
+		ContextBucket bucket = BY_CONTEXT.computeIfAbsent(key, k -> new ContextBucket());
+		bucket.touch();
+		bucket.entries.add(exchange);
 	}
 
 	/**
 	 * Snapshot of exchanges for a context (for reporting without removing).
 	 */
 	public static List<InternalApiLogExchange> snapshot(String contextKey) {
+		maybeExpireStaleContexts();
 		if (contextKey == null || contextKey.isBlank()) {
 			return snapshot(GLOBAL_LOG_KEY);
 		}
-		List<InternalApiLogExchange> list = BY_CONTEXT.get(contextKey);
-		if (list == null || list.isEmpty()) {
+		ContextBucket bucket = BY_CONTEXT.get(contextKey);
+		if (bucket == null || bucket.entries.isEmpty()) {
 			return List.of();
 		}
-		synchronized (list) {
-			return List.copyOf(list);
+		bucket.touch();
+		synchronized (bucket.entries) {
+			return List.copyOf(bucket.entries);
 		}
 	}
 
@@ -54,17 +109,19 @@ public final class InternalApiLogCollector {
 	 * Remove and return all exchanges for the context.
 	 */
 	public static List<InternalApiLogExchange> drain(String contextKey) {
+		maybeExpireStaleContexts();
 		String key = contextKey == null || contextKey.isBlank() ? GLOBAL_LOG_KEY : contextKey;
-		List<InternalApiLogExchange> removed = BY_CONTEXT.remove(key);
-		if (removed == null || removed.isEmpty()) {
+		ContextBucket removed = BY_CONTEXT.remove(key);
+		if (removed == null || removed.entries.isEmpty()) {
 			return List.of();
 		}
-		synchronized (removed) {
-			return new ArrayList<>(removed);
+		synchronized (removed.entries) {
+			return new ArrayList<>(removed.entries);
 		}
 	}
 
 	public static void clear(String contextKey) {
+		maybeExpireStaleContexts();
 		String key = contextKey == null || contextKey.isBlank() ? GLOBAL_LOG_KEY : contextKey;
 		BY_CONTEXT.remove(key);
 	}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogCollector.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogCollector.java
@@ -1,0 +1,71 @@
+package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * In-memory store of outbound API exchanges, keyed by Packet Creator /
+ * Data Provider context id.
+ */
+public final class InternalApiLogCollector {
+
+	private static final AtomicLong SEQ = new AtomicLong(1L);
+	private static final Map<String, List<InternalApiLogExchange>> BY_CONTEXT = new ConcurrentHashMap<>();
+
+	private InternalApiLogCollector() {
+	}
+
+	public static long nextSequence() {
+		return SEQ.getAndIncrement();
+	}
+
+	/** Bucket for outbound calls where no MOSIP context namespace exists (e.g. JVM-wide flag only). */
+	public static final String GLOBAL_LOG_KEY = "_dslrig_internal_api_global_";
+
+	public static void record(String contextKey, InternalApiLogExchange exchange) {
+		if (exchange == null) {
+			return;
+		}
+		String key = contextKey == null || contextKey.isBlank() ? GLOBAL_LOG_KEY : contextKey;
+		BY_CONTEXT.computeIfAbsent(key, k -> Collections.synchronizedList(new ArrayList<>())).add(exchange);
+	}
+
+	/**
+	 * Snapshot of exchanges for a context (for reporting without removing).
+	 */
+	public static List<InternalApiLogExchange> snapshot(String contextKey) {
+		if (contextKey == null || contextKey.isBlank()) {
+			return snapshot(GLOBAL_LOG_KEY);
+		}
+		List<InternalApiLogExchange> list = BY_CONTEXT.get(contextKey);
+		if (list == null || list.isEmpty()) {
+			return List.of();
+		}
+		synchronized (list) {
+			return List.copyOf(list);
+		}
+	}
+
+	/**
+	 * Remove and return all exchanges for the context.
+	 */
+	public static List<InternalApiLogExchange> drain(String contextKey) {
+		String key = contextKey == null || contextKey.isBlank() ? GLOBAL_LOG_KEY : contextKey;
+		List<InternalApiLogExchange> removed = BY_CONTEXT.remove(key);
+		if (removed == null || removed.isEmpty()) {
+			return List.of();
+		}
+		synchronized (removed) {
+			return new ArrayList<>(removed);
+		}
+	}
+
+	public static void clear(String contextKey) {
+		String key = contextKey == null || contextKey.isBlank() ? GLOBAL_LOG_KEY : contextKey;
+		BY_CONTEXT.remove(key);
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogExchange.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogExchange.java
@@ -1,0 +1,93 @@
+package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
+
+import java.time.Instant;
+
+/**
+ * One outbound HTTP exchange (request + response) in execution order.
+ */
+public final class InternalApiLogExchange {
+
+	private final long sequence;
+	private final String contextKey;
+	private final Instant requestInstant;
+	private final String method;
+	private final String url;
+	private final String requestHeaders;
+	private final String requestBody;
+	private volatile Instant responseInstant;
+	private volatile int statusCode;
+	private volatile String responseHeaders;
+	private volatile String responseBody;
+	private volatile String errorMessage;
+
+	public InternalApiLogExchange(long sequence, String contextKey, Instant requestInstant, String method,
+			String url, String requestHeaders, String requestBody) {
+		this.sequence = sequence;
+		this.contextKey = contextKey;
+		this.requestInstant = requestInstant;
+		this.method = method;
+		this.url = url;
+		this.requestHeaders = requestHeaders;
+		this.requestBody = requestBody;
+	}
+
+	public void setResponse(Instant responseInstant, int statusCode, String responseHeaders, String responseBody) {
+		this.responseInstant = responseInstant;
+		this.statusCode = statusCode;
+		this.responseHeaders = responseHeaders;
+		this.responseBody = responseBody;
+	}
+
+	public void setError(Instant responseInstant, String message) {
+		this.responseInstant = responseInstant;
+		this.errorMessage = message;
+	}
+
+	public long getSequence() {
+		return sequence;
+	}
+
+	public String getContextKey() {
+		return contextKey;
+	}
+
+	public Instant getRequestInstant() {
+		return requestInstant;
+	}
+
+	public Instant getResponseInstant() {
+		return responseInstant;
+	}
+
+	public String getMethod() {
+		return method;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public String getRequestHeaders() {
+		return requestHeaders;
+	}
+
+	public String getRequestBody() {
+		return requestBody;
+	}
+
+	public int getStatusCode() {
+		return statusCode;
+	}
+
+	public String getResponseHeaders() {
+		return responseHeaders;
+	}
+
+	public String getResponseBody() {
+		return responseBody;
+	}
+
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogExchange.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogExchange.java
@@ -1,93 +1,103 @@
-package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
-
-import java.time.Instant;
-
-/**
- * One outbound HTTP exchange (request + response) in execution order.
- */
-public final class InternalApiLogExchange {
-
-	private final long sequence;
-	private final String contextKey;
-	private final Instant requestInstant;
-	private final String method;
-	private final String url;
-	private final String requestHeaders;
-	private final String requestBody;
-	private volatile Instant responseInstant;
-	private volatile int statusCode;
-	private volatile String responseHeaders;
-	private volatile String responseBody;
-	private volatile String errorMessage;
-
-	public InternalApiLogExchange(long sequence, String contextKey, Instant requestInstant, String method,
-			String url, String requestHeaders, String requestBody) {
-		this.sequence = sequence;
-		this.contextKey = contextKey;
-		this.requestInstant = requestInstant;
-		this.method = method;
-		this.url = url;
-		this.requestHeaders = requestHeaders;
-		this.requestBody = requestBody;
-	}
-
-	public void setResponse(Instant responseInstant, int statusCode, String responseHeaders, String responseBody) {
-		this.responseInstant = responseInstant;
-		this.statusCode = statusCode;
-		this.responseHeaders = responseHeaders;
-		this.responseBody = responseBody;
-	}
-
-	public void setError(Instant responseInstant, String message) {
-		this.responseInstant = responseInstant;
-		this.errorMessage = message;
-	}
-
-	public long getSequence() {
-		return sequence;
-	}
-
-	public String getContextKey() {
-		return contextKey;
-	}
-
-	public Instant getRequestInstant() {
-		return requestInstant;
-	}
-
-	public Instant getResponseInstant() {
-		return responseInstant;
-	}
-
-	public String getMethod() {
-		return method;
-	}
-
-	public String getUrl() {
-		return url;
-	}
-
-	public String getRequestHeaders() {
-		return requestHeaders;
-	}
-
-	public String getRequestBody() {
-		return requestBody;
-	}
-
-	public int getStatusCode() {
-		return statusCode;
-	}
-
-	public String getResponseHeaders() {
-		return responseHeaders;
-	}
-
-	public String getResponseBody() {
-		return responseBody;
-	}
-
-	public String getErrorMessage() {
-		return errorMessage;
-	}
-}
+package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
+
+import java.time.Instant;
+
+/**
+ * One outbound HTTP exchange (request + response) in execution order.
+ * <p>
+ * Response-side fields are published through a single {@link Response} snapshot
+ * so concurrent readers (for example via {@link InternalApiLogCollector#snapshot})
+ * never observe a mix of old and new values.
+ */
+public final class InternalApiLogExchange {
+
+	/**
+	 * Immutable capture of the response phase (successful HTTP response or error
+	 * before completion). Published atomically via volatile on the enclosing
+	 * exchange.
+	 */
+	public static record Response(Instant responseInstant, int statusCode, String responseHeaders,
+			String responseBody, String errorMessage) {
+	}
+
+	private final long sequence;
+	private final String contextKey;
+	private final Instant requestInstant;
+	private final String method;
+	private final String url;
+	private final String requestHeaders;
+	private final String requestBody;
+	private volatile Response response;
+
+	public InternalApiLogExchange(long sequence, String contextKey, Instant requestInstant, String method,
+			String url, String requestHeaders, String requestBody) {
+		this.sequence = sequence;
+		this.contextKey = contextKey;
+		this.requestInstant = requestInstant;
+		this.method = method;
+		this.url = url;
+		this.requestHeaders = requestHeaders;
+		this.requestBody = requestBody;
+	}
+
+	public void setResponse(Instant responseInstant, int statusCode, String responseHeaders, String responseBody) {
+		this.response = new Response(responseInstant, statusCode, responseHeaders, responseBody, null);
+	}
+
+	public void setError(Instant responseInstant, String message) {
+		this.response = new Response(responseInstant, 0, null, null, message);
+	}
+
+	public long getSequence() {
+		return sequence;
+	}
+
+	public String getContextKey() {
+		return contextKey;
+	}
+
+	public Instant getRequestInstant() {
+		return requestInstant;
+	}
+
+	public Instant getResponseInstant() {
+		Response r = response;
+		return r == null ? null : r.responseInstant();
+	}
+
+	public String getMethod() {
+		return method;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public String getRequestHeaders() {
+		return requestHeaders;
+	}
+
+	public String getRequestBody() {
+		return requestBody;
+	}
+
+	public int getStatusCode() {
+		Response r = response;
+		return r == null ? 0 : r.statusCode();
+	}
+
+	public String getResponseHeaders() {
+		Response r = response;
+		return r == null ? null : r.responseHeaders();
+	}
+
+	public String getResponseBody() {
+		Response r = response;
+		return r == null ? null : r.responseBody();
+	}
+
+	public String getErrorMessage() {
+		Response r = response;
+		return r == null ? null : r.errorMessage();
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogFormatter.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogFormatter.java
@@ -1,0 +1,83 @@
+package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Pretty-prints collected exchanges: one section, one block per outbound call
+ * with request and response together (execution order).
+ */
+public final class InternalApiLogFormatter {
+
+	private static final String ENTRY_SEP = "\n--------------------------------------------------------------------------------\n";
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private InternalApiLogFormatter() {
+	}
+
+	public static String format(List<InternalApiLogExchange> exchanges) {
+		if (exchanges == null || exchanges.isEmpty()) {
+			return "OUTBOUND INTERNAL API CALLS\n(no internal API calls recorded for this context)\n";
+		}
+		StringBuilder out = new StringBuilder();
+		out.append("OUTBOUND INTERNAL API CALLS (execution order: request + response per call)\n");
+
+		int n = 1;
+		for (InternalApiLogExchange ex : exchanges) {
+			out.append(ENTRY_SEP);
+			out.append("Call #").append(n).append(" | sequence=").append(ex.getSequence()).append('\n');
+			out.append("URL           : ").append(safe(ex.getUrl())).append('\n');
+			out.append("HTTP Method   : ").append(safe(ex.getMethod())).append('\n');
+			out.append("Timestamp     : ").append(formatInstant(ex.getRequestInstant())).append('\n');
+			out.append("Headers       :\n").append(indent(safe(ex.getRequestHeaders()))).append('\n');
+			out.append("Request Body  :\n").append(indent(prettyIfJson(safe(ex.getRequestBody())))).append('\n');
+			out.append("--- Response ---\n");
+			if (ex.getErrorMessage() != null) {
+				out.append("Status Code   : (no HTTP response — error before completion)\n");
+				out.append("Headers       :\n  (n/a)\n");
+				out.append("Response Body :\n").append(indent(safe(ex.getErrorMessage()))).append('\n');
+			} else {
+				out.append("Status Code   : ").append(ex.getStatusCode()).append('\n');
+				out.append("Timestamp     : ").append(formatInstant(ex.getResponseInstant())).append('\n');
+				out.append("Headers       :\n").append(indent(safe(ex.getResponseHeaders()))).append('\n');
+				out.append("Response Body :\n").append(indent(prettyIfJson(safe(ex.getResponseBody())))).append('\n');
+			}
+			n++;
+		}
+		return out.toString();
+	}
+
+	private static String formatInstant(Instant i) {
+		return i == null ? "N/A" : i.toString();
+	}
+
+	private static String safe(String s) {
+		return s == null ? "" : s;
+	}
+
+	private static String indent(String block) {
+		if (block.isEmpty()) {
+			return "  (empty)";
+		}
+		return "  " + block.replace("\n", "\n  ");
+	}
+
+	private static String prettyIfJson(String raw) {
+		if (raw == null || raw.isBlank()) {
+			return "";
+		}
+		String t = raw.trim();
+		if (!(t.startsWith("{") || t.startsWith("["))) {
+			return raw;
+		}
+		try {
+			Object tree = MAPPER.readValue(t, Object.class);
+			return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(tree);
+		} catch (Exception e) {
+			return raw;
+		}
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogging.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiLogging.java
@@ -1,0 +1,32 @@
+package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
+
+import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
+
+/**
+ * Feature flag for outbound (internal) HTTP logging. When enabled, all calls
+ * routed through {@link io.mosip.testrig.dslrig.dataprovider.util.RestClient}
+ * capture request/response metadata for diagnostics.
+ * <p>
+ * Enable with either:
+ * <ul>
+ * <li>{@code -Ddslrig.internal.api.logging=true} on the JVM</li>
+ * <li>Variable {@code internalApiLogging=yes} in the Packet Creator / Data
+ * Provider context namespace (same mechanism as {@code enableDebug})</li>
+ * </ul>
+ */
+public final class InternalApiLogging {
+
+	private InternalApiLogging() {
+	}
+
+	public static boolean isEnabled(String contextKey) {
+		if (Boolean.parseBoolean(System.getProperty("dslrig.internal.api.logging", "false"))) {
+			return true;
+		}
+		if (contextKey == null || contextKey.isBlank()) {
+			return false;
+		}
+		Object v = VariableManager.getVariableValue(contextKey, "internalApiLogging");
+		return v != null && "yes".equalsIgnoreCase(String.valueOf(v).trim());
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiManualRecorder.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiManualRecorder.java
@@ -1,0 +1,44 @@
+package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
+
+import java.time.Instant;
+
+/**
+ * Records outbound HTTP that does not go through Rest Assured (Apache HttpClient,
+ * {@link java.net.HttpURLConnection}, etc.).
+ */
+public final class InternalApiManualRecorder {
+
+	private InternalApiManualRecorder() {
+	}
+
+	public static void record(String contextKey, String method, String url, String requestHeaders, String requestBody,
+			int statusCode, String responseHeaders, String responseBody) {
+		if (!InternalApiLogging.isEnabled(contextKey)) {
+			return;
+		}
+		String key = (contextKey == null || contextKey.isBlank()) ? InternalApiLogCollector.GLOBAL_LOG_KEY
+				: contextKey;
+		long seq = InternalApiLogCollector.nextSequence();
+		InternalApiLogExchange ex = new InternalApiLogExchange(seq, key, Instant.now(), method, url,
+				requestHeaders != null ? requestHeaders : "",
+				requestBody != null ? requestBody : "");
+		ex.setResponse(Instant.now(), statusCode, responseHeaders != null ? responseHeaders : "",
+				responseBody != null ? responseBody : "");
+		InternalApiLogCollector.record(key, ex);
+	}
+
+	public static void recordFailure(String contextKey, String method, String url, String requestHeaders,
+			String requestBody, String message) {
+		if (!InternalApiLogging.isEnabled(contextKey)) {
+			return;
+		}
+		String key = (contextKey == null || contextKey.isBlank()) ? InternalApiLogCollector.GLOBAL_LOG_KEY
+				: contextKey;
+		long seq = InternalApiLogCollector.nextSequence();
+		InternalApiLogExchange ex = new InternalApiLogExchange(seq, key, Instant.now(), method, url,
+				requestHeaders != null ? requestHeaders : "",
+				requestBody != null ? requestBody : "");
+		ex.setError(Instant.now(), message);
+		InternalApiLogCollector.record(key, ex);
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiRestAssuredFilter.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/internalapi/InternalApiRestAssuredFilter.java
@@ -1,0 +1,87 @@
+package io.mosip.testrig.dslrig.dataprovider.util.internalapi;
+
+import java.time.Instant;
+
+import io.restassured.filter.Filter;
+import io.restassured.filter.FilterContext;
+import io.restassured.response.Response;
+import io.restassured.specification.FilterableRequestSpecification;
+import io.restassured.specification.FilterableResponseSpecification;
+
+/**
+ * Captures Rest Assured outbound HTTP as {@link InternalApiLogExchange} entries.
+ */
+public final class InternalApiRestAssuredFilter implements Filter {
+
+	private final String storageKey;
+
+	public InternalApiRestAssuredFilter(String contextKey) {
+		this.storageKey = (contextKey == null || contextKey.isBlank()) ? InternalApiLogCollector.GLOBAL_LOG_KEY
+				: contextKey;
+	}
+
+	@Override
+	public Response filter(FilterableRequestSpecification requestSpec, FilterableResponseSpecification responseSpec,
+			FilterContext ctx) {
+		String uri = safeUri(requestSpec);
+		if (uri.contains("/context/internalApiLogs")) {
+			return ctx.next(requestSpec, responseSpec);
+		}
+
+		long seq = InternalApiLogCollector.nextSequence();
+		String method = requestSpec.getMethod() != null ? requestSpec.getMethod() : "";
+		String reqHeaders = headersToString(requestSpec);
+		String reqBody = bodyToString(requestSpec);
+
+		InternalApiLogExchange ex = new InternalApiLogExchange(seq, storageKey, Instant.now(), method, uri, reqHeaders,
+				reqBody);
+		InternalApiLogCollector.record(storageKey, ex);
+
+		try {
+			Response response = ctx.next(requestSpec, responseSpec);
+			String respHeaders = response.getHeaders() != null ? response.getHeaders().toString() : "";
+			String respBody = response.getBody() != null ? response.getBody().asString() : "";
+			ex.setResponse(Instant.now(), response.getStatusCode(), respHeaders, respBody);
+			return response;
+		} catch (RuntimeException e) {
+			ex.setError(Instant.now(), String.valueOf(e.getMessage()));
+			throw e;
+		}
+	}
+
+	private static String safeUri(FilterableRequestSpecification requestSpec) {
+		try {
+			String u = requestSpec.getURI();
+			return u != null ? u : "";
+		} catch (Exception e) {
+			return "";
+		}
+	}
+
+	private static String headersToString(FilterableRequestSpecification req) {
+		try {
+			if (req.getHeaders() == null) {
+				return "";
+			}
+			return req.getHeaders().toString();
+		} catch (Exception e) {
+			return "";
+		}
+	}
+
+	private static String bodyToString(FilterableRequestSpecification req) {
+		try {
+			if (req.getFormParams() != null && !req.getFormParams().isEmpty()) {
+				return "(x-www-form-urlencoded / form) " + req.getFormParams();
+			}
+		} catch (Exception ignored) {
+			// Rest Assured versions differ; form params may be unavailable for some specs.
+		}
+		try {
+			Object body = req.getBody();
+			return body != null ? body.toString() : "";
+		} catch (Exception e) {
+			return "";
+		}
+	}
+}


### PR DESCRIPTION
**The report should include:**
- API URL
- HTTP Method
- Request Headers
- Request Body
- Response Status Code
- Response Headers
- Response Body

**Expected Report Structure:**
- All API Requests section
- Separator line
- All API Responses section
- Properly formatted and pretty-printed JSON payloads
- Clear separation between each API entry

**Implementation Notes:**
- Ensure interceptors/wrappers/rest clients are properly registered and invoked across the project.
- Logs must be explicitly attached to the TestNG report using Reporter.log() or the framework reporting mechanism used in the project.
- The solution should work for all existing and future internal API calls without requiring manual logging in each controller/service.
- Perform end-to-end validation to confirm logs are visible in the final generated TestNG HTML report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal API logging capability that captures outbound API call details during test execution.
  * Test reports now include formatted logs of internal API traffic when logging is enabled.

* **Configuration**
  * New toggle to enable/disable internal API logging for reports via system property or configuration setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/mosip-automation-tests/pull/954)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->