### PR TITLE
MOSIP-45078-Implement unified DSL parameter resolution with scoped variable store before step run()

### DIFF
--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/base/PipelineStep.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/base/PipelineStep.java
@@ -16,7 +16,9 @@ import io.mosip.testrig.dslrig.ivv.core.pipeline.StepOutputs;
  *   <li>assert — orchestrator (HTTP status, error middleware, MOSIP body)</li>
  *   <li>publish — {@link #publishOutputs()}</li>
  * </ol>
- * MOSIP-specific steps should stay thin: bind parameters here, delegate domain work to helpers.
+ * MOSIP-specific steps should stay thin: use {@link io.mosip.testrig.dslrig.ivv.core.dsl.DslRuntime}
+ * via {@link #context} ({@code context.getDsl().resolve(...)} / {@code context.boundParameter(i)}),
+ * delegate domain work to helpers.
  */
 public abstract class PipelineStep extends BaseStep implements StepInterface {
 
@@ -30,9 +32,9 @@ public abstract class PipelineStep extends BaseStep implements StepInterface {
         publishOutputs();
     }
 
-    /** Resolve {@code $$} variables into {@link #context}. */
+    /** Resolve all step parameters through {@link io.mosip.testrig.dslrig.ivv.core.dsl.DslRuntime}. */
     protected void bind() throws RigInternalError {
-        context = StepBinder.bind(step);
+        context = StepBinder.bind(step, store);
     }
 
     /** Build requests, load templates, validate parameters. */

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/DslRuntime.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/DslRuntime.java
@@ -1,0 +1,106 @@
+package io.mosip.testrig.dslrig.ivv.core.dsl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.mosip.testrig.dslrig.ivv.core.dtos.Scenario;
+import io.mosip.testrig.dslrig.ivv.core.dtos.Store;
+import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
+import lombok.Getter;
+
+/**
+ * Entry point for DSL variable resolution before step {@code run()}.
+ * <pre>
+ *   ResolvedParameters params = dsl.resolve(step.getParameters());
+ *   String rid = params.require(0);
+ * </pre>
+ */
+@Getter
+public final class DslRuntime {
+
+    private final VariableStore store;
+    private final Scenario.Step step;
+
+    public DslRuntime(VariableStore store, Scenario.Step step) {
+        this.store = store;
+        this.step = step;
+    }
+
+    public static DslRuntime forStep(Scenario.Step step, Store suiteStore) {
+        VariableStore variableStore = VariableStore.forStep(step, suiteStore);
+        variableStore.clearStep();
+        return new DslRuntime(variableStore, step);
+    }
+
+    /**
+     * Resolves every raw parameter ( {@code $$} refs, readable names, globals) in one pass.
+     */
+    public ResolvedParameters resolve(List<String> rawParameters) throws RigInternalError {
+        List<String> bound = new ArrayList<>();
+        if (rawParameters != null) {
+            for (String param : rawParameters) {
+                bound.add(store.resolveReference(param));
+            }
+        }
+        return new ResolvedParameters(bound);
+    }
+
+    /**
+     * Resolves parameters and applies {@link ParameterSpec defaults}, required checks, and optional types.
+     */
+    public ResolvedParameters resolve(List<String> rawParameters, ParameterSpec... specs) throws RigInternalError {
+        ResolvedParameters base = resolve(rawParameters);
+        if (specs == null || specs.length == 0) {
+            return base;
+        }
+        List<ParameterSpec> specList = Arrays.asList(specs);
+        int maxIndex = specList.stream().mapToInt(ParameterSpec::getIndex).max().orElse(-1);
+        int size = Math.max(base.size(), maxIndex + 1);
+        List<String> merged = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            merged.add(null);
+        }
+        for (int i = 0; i < base.size(); i++) {
+            merged.set(i, base.get(i));
+        }
+        for (ParameterSpec spec : specList) {
+            int i = spec.getIndex();
+            while (merged.size() <= i) {
+                merged.add(null);
+            }
+            String value = i < base.size() ? base.get(i) : null;
+            if (isBlank(value)) {
+                if (spec.getDefaultValue() != null) {
+                    value = spec.getDefaultValue();
+                } else if (spec.isRequired()) {
+                    throw new RigInternalError("Required parameter '" + spec.getLabel() + "' at index " + i
+                            + " is missing");
+                }
+            }
+            if (value != null && spec.getType() != ParameterType.STRING) {
+                try {
+                    value = spec.getType().coerceToString(value, spec.getLabel());
+                } catch (IllegalArgumentException e) {
+                    throw new RigInternalError(e.getMessage());
+                }
+            }
+            merged.set(i, value);
+        }
+        return new ResolvedParameters(merged);
+    }
+
+    public void put(VariableScope scope, String key, String value) {
+        store.put(scope, key, value);
+    }
+
+    public void publishStepOutputs(java.util.Map<String, String> outputs) {
+        if (outputs != null) {
+            store.putAll(VariableScope.SCENARIO, outputs);
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/ParameterSpec.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/ParameterSpec.java
@@ -1,0 +1,48 @@
+package io.mosip.testrig.dslrig.ivv.core.dsl;
+
+import lombok.Getter;
+
+/**
+ * Declarative binding for one positional step parameter (defaults, required flag, optional type).
+ */
+@Getter
+public final class ParameterSpec {
+
+    private final int index;
+    private final String label;
+    private final ParameterType type;
+    private final String defaultValue;
+    private final boolean required;
+
+    private ParameterSpec(int index, String label, ParameterType type, String defaultValue, boolean required) {
+        this.index = index;
+        this.label = label != null && !label.isBlank() ? label : "param[" + index + "]";
+        this.type = type != null ? type : ParameterType.STRING;
+        this.defaultValue = defaultValue;
+        this.required = required;
+    }
+
+    public static ParameterSpec required(int index) {
+        return new ParameterSpec(index, null, ParameterType.STRING, null, true);
+    }
+
+    public static ParameterSpec required(int index, String label) {
+        return new ParameterSpec(index, label, ParameterType.STRING, null, true);
+    }
+
+    public static ParameterSpec optional(int index, String defaultValue) {
+        return new ParameterSpec(index, null, ParameterType.STRING, defaultValue, false);
+    }
+
+    public static ParameterSpec typed(int index, ParameterType type, boolean required) {
+        return new ParameterSpec(index, null, type, null, required);
+    }
+
+    public static ParameterSpec typed(int index, String label, ParameterType type, boolean required) {
+        return new ParameterSpec(index, label, type, null, required);
+    }
+
+    public static ParameterSpec typed(int index, String label, ParameterType type, String defaultValue) {
+        return new ParameterSpec(index, label, type, defaultValue, defaultValue == null);
+    }
+}

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/ParameterType.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/ParameterType.java
@@ -1,0 +1,46 @@
+package io.mosip.testrig.dslrig.ivv.core.dsl;
+
+/**
+ * Optional coercion applied after reference resolution.
+ */
+public enum ParameterType {
+    STRING,
+    INT,
+    LONG,
+    BOOLEAN;
+
+    public Object coerce(String value, String label) throws IllegalArgumentException {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        switch (this) {
+            case STRING:
+                return trimmed;
+            case INT:
+                try {
+                    return Integer.parseInt(trimmed);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Parameter '" + label + "' is not a valid int: [" + value + "]");
+                }
+            case LONG:
+                try {
+                    return Long.parseLong(trimmed);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Parameter '" + label + "' is not a valid long: [" + value + "]");
+                }
+            case BOOLEAN:
+                if ("true".equalsIgnoreCase(trimmed) || "false".equalsIgnoreCase(trimmed)) {
+                    return Boolean.parseBoolean(trimmed);
+                }
+                throw new IllegalArgumentException("Parameter '" + label + "' is not a valid boolean: [" + value + "]");
+            default:
+                return trimmed;
+        }
+    }
+
+    public String coerceToString(String value, String label) throws IllegalArgumentException {
+        Object coerced = coerce(value, label);
+        return coerced == null ? null : coerced.toString();
+    }
+}

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/ResolvedParameters.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/ResolvedParameters.java
@@ -1,0 +1,60 @@
+package io.mosip.testrig.dslrig.ivv.core.dsl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
+import lombok.Getter;
+
+/**
+ * Immutable list of parameter values after {@link DslRuntime#resolve(List)}.
+ */
+@Getter
+public final class ResolvedParameters {
+
+    private final List<String> values;
+
+    ResolvedParameters(List<String> values) {
+        this.values = Collections.unmodifiableList(new ArrayList<>(values));
+    }
+
+    public List<String> asList() {
+        return values;
+    }
+
+    public int size() {
+        return values.size();
+    }
+
+    public String get(int index) {
+        if (index < 0 || index >= values.size()) {
+            return null;
+        }
+        return values.get(index);
+    }
+
+    public String require(int index) throws RigInternalError {
+        String v = get(index);
+        if (v == null || v.isBlank()) {
+            throw new RigInternalError("Required parameter at index " + index + " is missing or empty");
+        }
+        return v;
+    }
+
+    public int getInt(int index) throws RigInternalError {
+        try {
+            return Integer.parseInt(require(index));
+        } catch (NumberFormatException e) {
+            throw new RigInternalError("Parameter at index " + index + " is not a valid int: [" + get(index) + "]");
+        }
+    }
+
+    public boolean getBoolean(int index) throws RigInternalError {
+        String v = require(index);
+        if ("true".equalsIgnoreCase(v) || "false".equalsIgnoreCase(v)) {
+            return Boolean.parseBoolean(v);
+        }
+        throw new RigInternalError("Parameter at index " + index + " is not a valid boolean: [" + v + "]");
+    }
+}

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/VariableScope.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/VariableScope.java
@@ -1,0 +1,10 @@
+package io.mosip.testrig.dslrig.ivv.core.dsl;
+
+/**
+ * Variable layers consulted in order: {@link #STEP} → {@link #SCENARIO} → {@link #GLOBAL}.
+ */
+public enum VariableScope {
+    GLOBAL,
+    SCENARIO,
+    STEP
+}

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/VariableStore.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/dsl/VariableStore.java
@@ -1,0 +1,198 @@
+package io.mosip.testrig.dslrig.ivv.core.dsl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import io.mosip.testrig.dslrig.ivv.core.dtos.Scenario;
+import io.mosip.testrig.dslrig.ivv.core.dtos.Store;
+import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
+
+/**
+ * Single variable store with {@link VariableScope#STEP step}, {@link VariableScope#SCENARIO scenario},
+ * and {@link VariableScope#GLOBAL global} layers. Lookup order: step → scenario → global.
+ */
+public final class VariableStore {
+
+    private final Map<String, String> global;
+    private final Map<String, String> scenario;
+    private final Map<String, String> step = new HashMap<>();
+
+    public VariableStore(Map<String, String> global, Map<String, String> scenario) {
+        this.global = global != null ? global : Collections.emptyMap();
+        this.scenario = scenario != null ? scenario : Collections.emptyMap();
+    }
+
+    public static VariableStore forStep(Scenario.Step step, Store store) {
+        Map<String, String> globals = store != null && store.getGlobals() != null
+                ? store.getGlobals()
+                : Collections.emptyMap();
+        Map<String, String> scenarioVars = step != null && step.getScenario() != null
+                && step.getScenario().getVariables() != null
+                ? step.getScenario().getVariables()
+                : Collections.emptyMap();
+        return new VariableStore(globals, scenarioVars);
+    }
+
+    public void clearStep() {
+        step.clear();
+    }
+
+    public void put(VariableScope scope, String key, String value) {
+        if (key == null || value == null) {
+            return;
+        }
+        String normalized = normalizeDslKey(key);
+        switch (scope) {
+            case STEP:
+                step.put(normalized, value);
+                break;
+            case SCENARIO:
+                if (scenario instanceof HashMap) {
+                    ((HashMap<String, String>) scenario).put(normalized, value);
+                }
+                break;
+            case GLOBAL:
+                if (global instanceof HashMap) {
+                    ((HashMap<String, String>) global).put(normalized, value);
+                    String bare = bareKey(normalized);
+                    if (!bare.equals(normalized)) {
+                        ((HashMap<String, String>) global).put(bare, value);
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void putAll(VariableScope scope, Map<String, String> values) {
+        if (values == null) {
+            return;
+        }
+        for (Map.Entry<String, String> e : values.entrySet()) {
+            put(scope, e.getKey(), e.getValue());
+        }
+    }
+
+    public boolean contains(String dslKey) {
+        return lookupRaw(normalizeDslKey(dslKey)) != null;
+    }
+
+    public String resolveReference(String raw) throws RigInternalError {
+        if (isBlank(raw)) {
+            return raw;
+        }
+        String normalized = stripInlineAnnotations(raw.trim());
+        if (normalized.startsWith("$$")) {
+            return requireNonEmpty(lookupScoped(normalized), normalized);
+        }
+        String variableKey = "$$" + toDslVariableName(normalized);
+        if (containsInAnyScope(variableKey)) {
+            return requireNonEmpty(lookupScoped(variableKey), variableKey);
+        }
+        return normalized;
+    }
+
+    public boolean referencesVariable(String raw) {
+        if (isBlank(raw)) {
+            return false;
+        }
+        String normalized = stripInlineAnnotations(raw.trim());
+        if (normalized.startsWith("$$")) {
+            return true;
+        }
+        return containsInAnyScope("$$" + toDslVariableName(normalized));
+    }
+
+    public static String toDslVariableName(String displayName) {
+        String[] words = displayName.trim().split("\\s+");
+        if (words.length == 0) {
+            return displayName;
+        }
+        StringBuilder sb = new StringBuilder(words[0].toLowerCase(Locale.ROOT));
+        for (int i = 1; i < words.length; i++) {
+            String w = words[i];
+            if (!w.isEmpty()) {
+                sb.append(Character.toUpperCase(w.charAt(0)));
+                if (w.length() > 1) {
+                    sb.append(w.substring(1).toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    Map<String, String> stepView() {
+        return Collections.unmodifiableMap(step);
+    }
+
+    private String lookupScoped(String dslKey) {
+        String key = normalizeDslKey(dslKey);
+        String value = lookupRaw(key);
+        if (value != null) {
+            return value;
+        }
+        String bare = bareKey(key);
+        if (!bare.equals(key)) {
+            value = lookupRaw("$$" + bare);
+            if (value != null) {
+                return value;
+            }
+            value = lookupRaw(bare);
+        }
+        return value;
+    }
+
+    private String lookupRaw(String dslKey) {
+        if (step.containsKey(dslKey)) {
+            return step.get(dslKey);
+        }
+        if (scenario.containsKey(dslKey)) {
+            return scenario.get(dslKey);
+        }
+        if (global.containsKey(dslKey)) {
+            return global.get(dslKey);
+        }
+        String bare = bareKey(dslKey);
+        if (global.containsKey(bare)) {
+            return global.get(bare);
+        }
+        return null;
+    }
+
+    private boolean containsInAnyScope(String dslKey) {
+        String key = normalizeDslKey(dslKey);
+        return step.containsKey(key) || scenario.containsKey(key) || global.containsKey(key)
+                || global.containsKey(bareKey(key));
+    }
+
+    private static String requireNonEmpty(String value, String key) throws RigInternalError {
+        if (value != null && !value.isBlank()) {
+            return value;
+        }
+        throw new RigInternalError("Variable is not set or empty: " + key
+                + " (checked scopes: step, scenario, global)");
+    }
+
+    private static String normalizeDslKey(String key) {
+        if (key == null) {
+            return "";
+        }
+        String k = key.trim();
+        return k.startsWith("$$") ? k : "$$" + k;
+    }
+
+    private static String bareKey(String dslKey) {
+        return dslKey.startsWith("$$") ? dslKey.substring(2) : dslKey;
+    }
+
+    private static String stripInlineAnnotations(String value) {
+        return value.replaceAll("/\\*[^*]*\\*/", "").trim();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/pipeline/StepBinder.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/pipeline/StepBinder.java
@@ -1,15 +1,14 @@
 package io.mosip.testrig.dslrig.ivv.core.pipeline;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
+import io.mosip.testrig.dslrig.ivv.core.dsl.DslRuntime;
+import io.mosip.testrig.dslrig.ivv.core.dsl.ResolvedParameters;
+import io.mosip.testrig.dslrig.ivv.core.dsl.VariableStore;
 import io.mosip.testrig.dslrig.ivv.core.dtos.Scenario;
+import io.mosip.testrig.dslrig.ivv.core.dtos.Store;
 import io.mosip.testrig.dslrig.ivv.core.exceptions.RigInternalError;
 
 /**
- * Resolves {@code $$} scenario references in step parameters (bind phase).
- * Parse happens in ivv-parser; orchestrator invokes bind immediately before prepare/execute.
+ * Bind phase: resolves step parameters via {@link DslRuntime} before prepare/execute.
  */
 public final class StepBinder {
 
@@ -17,69 +16,31 @@ public final class StepBinder {
     }
 
     public static StepContext bind(Scenario.Step step) throws RigInternalError {
-        List<String> raw = step.getParameters();
-        List<String> bound = new ArrayList<>();
-        if (raw != null) {
-            for (String param : raw) {
-                bound.add(resolveScenarioVariable(step, param));
-            }
-        }
-        return new StepContext(step, bound);
+        return bind(step, null);
+    }
+
+    public static StepContext bind(Scenario.Step step, Store suiteStore) throws RigInternalError {
+        DslRuntime dsl = DslRuntime.forStep(step, suiteStore);
+        ResolvedParameters resolved = dsl.resolve(step.getParameters());
+        return new StepContext(step, dsl, resolved);
     }
 
     public static boolean referencesScenarioVariable(Scenario.Step step, String value) {
-        if (isBlank(value)) {
+        if (step == null) {
             return false;
         }
-        String normalized = value.trim().replaceAll("/\\*[^*]*\\*/", "").trim();
-        if (normalized.startsWith("$$")) {
-            return true;
-        }
-        return step.getScenario().getVariables().containsKey("$$" + toDslVariableName(normalized));
+        return VariableStore.forStep(step, null).referencesVariable(value);
     }
 
     public static String resolveScenarioVariable(Scenario.Step step, String value) throws RigInternalError {
-        if (isBlank(value)) {
+        if (step == null) {
             return value;
         }
-        String normalized = value.trim().replaceAll("/\\*[^*]*\\*/", "").trim();
-        if (normalized.startsWith("$$")) {
-            String resolved = step.getScenario().getVariables().get(normalized);
-            if (resolved != null && !resolved.isBlank()) {
-                return resolved;
-            }
-            throw new RigInternalError("Scenario variable is not set or empty: " + normalized);
-        }
-        String variableKey = "$$" + toDslVariableName(normalized);
-        if (step.getScenario().getVariables().containsKey(variableKey)) {
-            String resolved = step.getScenario().getVariables().get(variableKey);
-            if (resolved != null && !resolved.isBlank()) {
-                return resolved;
-            }
-            throw new RigInternalError("Scenario variable is not set or empty: " + variableKey);
-        }
-        return normalized;
+        return VariableStore.forStep(step, null).resolveReference(value);
     }
 
+    /** @deprecated Use {@link VariableStore#toDslVariableName(String)}. */
     public static String toDslVariableName(String displayName) {
-        String[] words = displayName.trim().split("\\s+");
-        if (words.length == 0) {
-            return displayName;
-        }
-        StringBuilder sb = new StringBuilder(words[0].toLowerCase(Locale.ROOT));
-        for (int i = 1; i < words.length; i++) {
-            String w = words[i];
-            if (!w.isEmpty()) {
-                sb.append(Character.toUpperCase(w.charAt(0)));
-                if (w.length() > 1) {
-                    sb.append(w.substring(1).toLowerCase(Locale.ROOT));
-                }
-            }
-        }
-        return sb.toString();
-    }
-
-    private static boolean isBlank(String value) {
-        return value == null || value.trim().isEmpty();
+        return VariableStore.toDslVariableName(displayName);
     }
 }

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/pipeline/StepContext.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/pipeline/StepContext.java
@@ -1,29 +1,29 @@
 package io.mosip.testrig.dslrig.ivv.core.pipeline;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import io.mosip.testrig.dslrig.ivv.core.dsl.DslRuntime;
+import io.mosip.testrig.dslrig.ivv.core.dsl.ResolvedParameters;
 import io.mosip.testrig.dslrig.ivv.core.dtos.Scenario;
 import lombok.Getter;
 
 /**
- * Bound view of a DSL step after {@link StepBinder#bind(Scenario.Step)} — scenario variables
- * resolved, outputs collected for {@link PipelineStep#publishOutputs()}.
+ * Bound view of a DSL step after {@link StepBinder#bind(Scenario.Step, io.mosip.testrig.dslrig.ivv.core.dtos.Store)}.
  */
 @Getter
 public class StepContext {
     private final Scenario.Step step;
-    private final List<String> boundParameters;
+    private final DslRuntime dsl;
+    private final ResolvedParameters parameters;
     private final String outVarName;
     private final Map<String, String> outputs = new HashMap<>();
 
-    public StepContext(Scenario.Step step, List<String> boundParameters) {
+    public StepContext(Scenario.Step step, DslRuntime dsl, ResolvedParameters parameters) {
         this.step = step;
-        this.boundParameters = Collections.unmodifiableList(new ArrayList<>(boundParameters));
-        this.outVarName = step.getOutVarName();
+        this.dsl = dsl;
+        this.parameters = parameters;
+        this.outVarName = step != null ? step.getOutVarName() : null;
     }
 
     public void putOutput(String key, String value) {
@@ -39,9 +39,6 @@ public class StepContext {
     }
 
     public String boundParameter(int index) {
-        if (index < 0 || index >= boundParameters.size()) {
-            return null;
-        }
-        return boundParameters.get(index);
+        return parameters != null ? parameters.get(index) : null;
     }
 }

--- a/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/pipeline/StepOutputs.java
+++ b/mosip-acceptance-tests/ivv-core/src/main/java/io/mosip/testrig/dslrig/ivv/core/pipeline/StepOutputs.java
@@ -1,5 +1,6 @@
 package io.mosip.testrig.dslrig.ivv.core.pipeline;
 
+import io.mosip.testrig.dslrig.ivv.core.dsl.VariableScope;
 import io.mosip.testrig.dslrig.ivv.core.dtos.Scenario;
 
 public final class StepOutputs {
@@ -11,12 +12,18 @@ public final class StepOutputs {
         if (context == null || step == null || step.getScenario() == null) {
             return;
         }
-        if (!context.getOutputs().isEmpty()) {
+        if (context.getDsl() != null && !context.getOutputs().isEmpty()) {
+            context.getDsl().publishStepOutputs(context.getOutputs());
+        } else if (!context.getOutputs().isEmpty()) {
             step.getScenario().getVariables().putAll(context.getOutputs());
         }
         String outVar = context.getOutVarName();
         if (outVar != null && context.getOutputs().containsKey(outVar)) {
-            step.getScenario().getVariables().put(outVar, context.getOutputs().get(outVar));
+            if (context.getDsl() != null) {
+                context.getDsl().put(VariableScope.SCENARIO, outVar, context.getOutputs().get(outVar));
+            } else {
+                step.getScenario().getVariables().put(outVar, context.getOutputs().get(outVar));
+            }
         }
     }
 }

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/Wait.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/Wait.java
@@ -63,7 +63,7 @@ public class Wait extends BaseTestCaseUtil implements StepInterface {
 			String finalMsg = " Wait Time  " + (waitTime / 1000) + " seconds";
 			logger.info(finalMsg);
 			Reporter.log(finalMsg, true);
-			Thread.sleep(waitTime);
+			sleepWithCountdown(waitTime, "Wait");
 
 		} catch (NumberFormatException e) {
 			logger.error("Invalid wait time format: " + e.getMessage());

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/WaitTillReprocessorInterval.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/e2e/methods/WaitTillReprocessorInterval.java
@@ -30,7 +30,7 @@ public class WaitTillReprocessorInterval extends BaseTestCaseUtil implements Ste
 
 		try {
 			Reporter.log("Total waiting for: " + waitTime / 1000 + " Sec" + " Starting Waiting: " + getDateTime());
-			Thread.sleep(waitTime);
+			sleepWithCountdown(waitTime, "Reprocessor wait");
 			Reporter.log("Waiting Done: " + getDateTime());
 		} catch (NumberFormatException e) {
 			logger.error(e.getMessage());

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/BaseTestCaseUtil.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/BaseTestCaseUtil.java
@@ -2,6 +2,7 @@ package io.mosip.testrig.dslrig.ivv.orchestrator;
 
 import static io.restassured.RestAssured.given;
 
+import java.io.Console;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -60,6 +61,71 @@ public class BaseTestCaseUtil extends BaseStep {
 	public static final long DEFAULT_WAIT_TIME = 30000l;
 	public static final long TIME_IN_MILLISEC = 1000l;
 
+	/**
+	 * Sleeps for the given duration while updating a single console line every second
+	 * (e.g. "Wait: 90 sec remaining" becomes 89, 88 … on the same line).
+	 */
+	public static void sleepWithCountdown(long waitTimeMs) throws InterruptedException {
+		sleepWithCountdown(waitTimeMs, "Waiting");
+	}
+
+	public static void sleepWithCountdown(long waitTimeMs, String label) throws InterruptedException {
+		if (waitTimeMs <= 0) {
+			return;
+		}
+		String prefix = (label == null || label.isBlank()) ? "Waiting" : label.trim();
+		long endTime = System.currentTimeMillis() + waitTimeMs;
+		long totalSeconds = (waitTimeMs + TIME_IN_MILLISEC - 1) / TIME_IN_MILLISEC;
+		Console console = System.console();
+		int printedLength = 0;
+
+		while (true) {
+			long remainingMs = endTime - System.currentTimeMillis();
+			if (remainingMs <= 0) {
+				break;
+			}
+			long remainingSec = (remainingMs + TIME_IN_MILLISEC - 1) / TIME_IN_MILLISEC;
+			String line = String.format("%s: %3d sec remaining", prefix, remainingSec);
+
+			if (console != null) {
+				console.writer().printf("\r%-40s", line);
+				console.writer().flush();
+			} else {
+				if (printedLength > 0) {
+					eraseConsoleLine(printedLength);
+				}
+				System.out.print(line);
+				System.out.flush();
+				printedLength = line.length();
+			}
+
+			Thread.sleep(Math.min(TIME_IN_MILLISEC, remainingMs));
+		}
+
+		String doneLine = String.format("%s: completed (%d sec)", prefix, totalSeconds);
+		if (console != null) {
+			console.writer().printf("\r%-40s%n", doneLine);
+			console.writer().flush();
+		} else {
+			if (printedLength > 0) {
+				eraseConsoleLine(printedLength);
+			}
+			System.out.println(doneLine);
+		}
+	}
+
+	/** Erases {@code length} characters so the next print reuses the same console line. */
+	private static void eraseConsoleLine(int length) {
+		for (int i = 0; i < length; i++) {
+			System.out.print('\b');
+		}
+		for (int i = 0; i < length; i++) {
+			System.out.print(' ');
+		}
+		for (int i = 0; i < length; i++) {
+			System.out.print('\b');
+		}
+	}
 
 	private static final int INTERNAL_API_LOG_FETCH_CONNECT_MS = 10_000;
 

--- a/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/pipeline/HttpPipelineStep.java
+++ b/mosip-acceptance-tests/ivv-orchestrator/src/main/java/io/mosip/testrig/dslrig/ivv/orchestrator/pipeline/HttpPipelineStep.java
@@ -23,7 +23,7 @@ public abstract class HttpPipelineStep extends BaseTestCaseUtil implements StepI
 
     @Override
     public final void run() throws RigInternalError, FeatureNotSupportedError {
-        context = StepBinder.bind(step);
+        context = StepBinder.bind(step, store);
         prepareRequest();
         RequestDataDTO request = buildRequest();
         if (request != null) {


### PR DESCRIPTION
DSL step implementations resolve parameters inconsistently: direct step.getParameters().get(n), manual step.getScenario().getVariables().get("$$..."), and partial logic in StepBinder. There is no single place for scope precedence, defaults, typed parameters, or consistent missing-variable errors before run().

Solution
Introduce a unified resolution layer that runs in the bind phase (before prepare() / execute()):

One API: dsl.resolve(step.getParameters()) (optional ParameterSpec... for defaults/types)
One store: VariableStore with STEP → SCENARIO → GLOBAL lookup order
Fail fast when a $$ reference or readable name cannot be resolved
Optional parameter specs: required, default value, type coercion (STRING, INT, LONG, BOOLEAN)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Countdown-based wait display for improved visibility during test execution delays.
  * Enhanced parameter resolution and type coercion for improved data handling.

* **Improvements**
  * Refactored pipeline parameter binding to use centralized DSL runtime for consistency.
  * Improved variable resolution across global, scenario, and step scopes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/mosip-automation-tests/pull/978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->