### PR TITLE
MOSIP-45079--Optimize mosipTestDataProvider & packet-creator for parallel DSL runs (auth isolation, unified cache, lazy biometrics, maintainability refactor)

### DIFF
--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/RunCacheController.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/controller/RunCacheController.java
@@ -38,7 +38,8 @@ public class RunCacheController {
 
 	@Operation(summary = "Warm run-scoped cache",
 			description = "Fetches auth tokens and frequently used masterdata once and stores them in the run cache "
-					+ "({urlBase}run_context) for reuse across all scenarios in the suite.")
+					+ "({urlBase}run_context, MasterdataCache md:get:/md:entity: keys) for reuse across all scenarios. "
+					+ "Call once per DSL context/worker before scenarios; pair with clear after the suite.")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Cache warmed") })
 	@PostMapping(value = "/runCache/warm/{contextKey}")
 	public @ResponseBody ResponseEntity<Map<String, Object>> warmRunCache(@PathVariable("contextKey") String contextKey) {

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/APIRequestUtil.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/APIRequestUtil.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -25,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import io.mosip.testrig.dslrig.dataprovider.preparation.MosipDataSetup;
+import io.mosip.testrig.dslrig.dataprovider.util.AuthTokenStore;
 import io.mosip.testrig.dslrig.dataprovider.util.RestClient;
 import io.mosip.testrig.dslrig.dataprovider.util.SlackIt;
 import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
@@ -43,11 +43,6 @@ public class APIRequestUtil {
     Logger logger = LoggerFactory.getLogger(APIRequestUtil.class);
 	private static final String DATEFORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
-
-	static Map<String, String> tokens = new HashMap<String,String>();
-
-
-    String refreshToken;
 
     @Value("${mosip.test.regclient.userid}")
     private String operatorId;
@@ -110,26 +105,16 @@ public class APIRequestUtil {
 
 	}
 
+    /**
+     * @deprecated Prefer {@link #clearRunScopedCache(String)} for a single DSL context.
+     */
+    @Deprecated
     public void clearToken() {
-    	tokens.clear();
+    	AuthTokenStore.clearAll();
     }
 
     public void clearRunScopedCache(String contextKey) {
-    	clearTokensForContext(contextKey);
-    	MosipDataSetup.clearRunCache(contextKey);
     	RestClient.clearRunScopedCache(contextKey);
-    }
-
-    private void clearTokensForContext(String contextKey) {
-    	try {
-    		Object urlBase = VariableManager.getVariableValue(contextKey, "urlBase");
-    		if (urlBase != null) {
-    			String prefix = urlBase.toString().trim();
-    			tokens.keySet().removeIf(key -> key.startsWith(prefix));
-    		}
-    	} catch (Exception e) {
-    		logger.debug("Could not clear in-memory tokens for context {}", contextKey);
-    	}
     }
 
     private boolean shouldForceAuthRefresh(String contextKey) {
@@ -238,7 +223,7 @@ public class APIRequestUtil {
 
     	while(!bDone) {
 
-    		Cookie kukki = new Cookie.Builder("Authorization", tokens.get(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system")).build();
+    		Cookie kukki = new Cookie.Builder("Authorization", AuthTokenStore.get(contextKey, AuthTokenStore.ROLE_SYSTEM)).build();
     		response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(requestParams.toMap()).get(url,pathParam.toMap());
     		if(response.getStatusCode() == 401) {
     			if(nLoop >= 1)
@@ -275,7 +260,7 @@ public class APIRequestUtil {
 
     	while(!bDone) {
 
-    		Cookie kukki = new Cookie.Builder("Authorization", tokens.get(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system")).build();
+    		Cookie kukki = new Cookie.Builder("Authorization", AuthTokenStore.get(contextKey, AuthTokenStore.ROLE_SYSTEM)).build();
     		response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(requestParams.toMap()).get(url,pathParam.toMap());
     		if(response.getStatusCode() == 401) {
     			if(nLoop >= 1)
@@ -315,7 +300,7 @@ public class APIRequestUtil {
 
     	while(!bDone) {
 
-    		Cookie kukki = new Cookie.Builder("Authorization",tokens.get(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system")).build();
+    		Cookie kukki = new Cookie.Builder("Authorization",AuthTokenStore.get(contextKey, AuthTokenStore.ROLE_SYSTEM)).build();
     		response = given().cookie(kukki).contentType(ContentType.JSON).queryParams(requestParams.toMap()).get(url,pathParam.toMap());
     		if(response.getStatusCode() == 401) {
     			if(nLoop >= 1)
@@ -355,7 +340,7 @@ public class APIRequestUtil {
     	Response response =null;
 
     	while(!bDone) {
-    		Cookie kukki = new Cookie.Builder("Authorization", tokens.get(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system")).build();
+    		Cookie kukki = new Cookie.Builder("Authorization", AuthTokenStore.get(contextKey, AuthTokenStore.ROLE_SYSTEM)).build();
     		response = given().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
     		if(response.getStatusCode() == 401) {
     			if(nLoop >= 1)
@@ -383,7 +368,7 @@ public class APIRequestUtil {
 		String centerId= VariableManager.getVariableValue(contextKey, "mosip.test.regclient.centerid").toString();
 		String machineId=VariableManager.getVariableValue(contextKey, "machineid").toString();
     	loadContext(contextKey);
-    	 tokens.put(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system",null);
+    	 AuthTokenStore.remove(contextKey, AuthTokenStore.ROLE_SYSTEM);
     	if (!isValidToken(contextKey)){
             initToken(contextKey);
         }
@@ -399,7 +384,7 @@ public class APIRequestUtil {
     		objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     		String outputJson = objectMapper.writeValueAsString(requestBody);
 
-            String authToken = tokens.get(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system");
+            String authToken = AuthTokenStore.get(contextKey, AuthTokenStore.ROLE_SYSTEM);
     		Cookie kukki = new Cookie.Builder("Authorization", authToken).build();
     		response = given().cookie(kukki)
                 .header("timestamp", timestamp)
@@ -434,7 +419,7 @@ public class APIRequestUtil {
 
 
     	loadContext(contextKey);
-    	tokens.put(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system",null);
+    	AuthTokenStore.remove(contextKey, AuthTokenStore.ROLE_SYSTEM);
 
 
     	if (!isValidToken(contextKey)){
@@ -442,7 +427,7 @@ public class APIRequestUtil {
         }
     	File f = new File(filePath);
 
-        Cookie kukki = new Cookie.Builder("Authorization", tokens.get(VariableManager.getVariableValue(contextKey,"urlBase").toString().trim()+"system")
+        Cookie kukki = new Cookie.Builder("Authorization", AuthTokenStore.get(contextKey, AuthTokenStore.ROLE_SYSTEM)
             	).build();
         Response response = given().cookie(kukki).multiPart("file", f.getCanonicalFile()).post(url);
         addServerApiTrace(contextKey, "POST", url,
@@ -454,23 +439,20 @@ public class APIRequestUtil {
     }
 
     private boolean isValidToken(String contextKey) throws Exception {
-    	Object obj = VariableManager.getVariableValue(contextKey,"urlSwitched");
-    	if(obj != null) {
-    		Boolean bClear = Boolean.valueOf(obj.toString());
-    		if(bClear)
-
-    			return false;
+    	if (shouldForceAuthRefresh(contextKey)) {
+    		return false;
     	}
-    	String urlBase = VariableManager.getVariableValue(contextKey,"urlBase").toString().trim();
-    	String tokenKey = urlBase + "system";
-    	String token = tokens.get(tokenKey);
+    	String token = AuthTokenStore.get(contextKey, AuthTokenStore.ROLE_SYSTEM);
     	if (token == null || token.isEmpty()) {
     		token = getRunCachedInternalAuthToken(contextKey);
     		if (token != null && !token.isEmpty()) {
-    			tokens.put(tokenKey, token);
+    			AuthTokenStore.put(contextKey, AuthTokenStore.ROLE_SYSTEM, token);
     		}
     	}
-    	return token != null && !token.isEmpty();
+    	if (token == null || token.isEmpty()) {
+    		return false;
+    	}
+    	return RestClient.isValidTokenOffline(token, contextKey);
     }
 
     private JSONObject buildInternalUseridPwdRequest(String contextKey) {
@@ -522,7 +504,7 @@ public class APIRequestUtil {
 			if (!shouldForceAuthRefresh(contextKey)) {
 				String cachedToken = getRunCachedInternalAuthToken(contextKey);
 				if (cachedToken != null && !cachedToken.isEmpty()) {
-					tokens.put(urlBase + "system", cachedToken);
+					AuthTokenStore.put(contextKey, AuthTokenStore.ROLE_SYSTEM, cachedToken);
 					return true;
 				}
 			}
@@ -552,7 +534,7 @@ public class APIRequestUtil {
             }
            String token = new JSONObject(response.getBody().asString()).getJSONObject(dataKey).getString("token");
 
-           tokens.put(urlBase + "system", token);
+           AuthTokenStore.put(contextKey, AuthTokenStore.ROLE_SYSTEM, token);
            cacheInternalAuthToken(contextKey, nestedRequest, token);
 
 
@@ -591,7 +573,7 @@ public class APIRequestUtil {
 			if (!shouldForceAuthRefresh(contextKey)) {
 				String cachedToken = getRunCachedInternalAuthToken(contextKey);
 				if (cachedToken != null && !cachedToken.isEmpty()) {
-					tokens.put(urlBase + "system", cachedToken);
+					AuthTokenStore.put(contextKey, AuthTokenStore.ROLE_SYSTEM, cachedToken);
 					return true;
 				}
 			}
@@ -622,7 +604,7 @@ public class APIRequestUtil {
         token= new JSONObject(response.getBody().asString()).getJSONObject(dataKey).getString("token");
 
 
-            tokens.put(urlBase + "system", token);
+            AuthTokenStore.put(contextKey, AuthTokenStore.ROLE_SYSTEM, token);
             cacheInternalAuthToken(contextKey, nestedRequest, token);
 			return true;	
 		}

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
@@ -41,6 +41,7 @@ import org.springframework.stereotype.Service;
 import io.mosip.testrig.dslrig.dataprovider.NameProvider;
 import io.mosip.testrig.dslrig.dataprovider.PacketTemplateProvider;
 import io.mosip.testrig.dslrig.dataprovider.ResidentDataProvider;
+import io.mosip.testrig.dslrig.dataprovider.persona.PersonaBiometricsAssembler;
 import io.mosip.testrig.dslrig.dataprovider.models.AppointmentModel;
 import io.mosip.testrig.dslrig.dataprovider.models.AppointmentTimeSlotModel;
 import io.mosip.testrig.dslrig.dataprovider.models.BiometricDataModel;
@@ -917,6 +918,7 @@ public class PacketSyncService {
 			}
 			for (String path : personaFilePaths) {
 				ResidentModel resident = ResidentModel.readPersona(path);
+				PersonaBiometricsAssembler.ensureAssembled(resident, null, contextKey);
 				String packetPath = packetDir.toString() + File.separator + resident.getId();
 				RestClient.logInfo(contextKey, "packetPath=" + packetPath);
 				String returnMsg = packetTemplateProvider.generate("registration_client", process, resident, packetPath,

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PacketSyncService.java
@@ -918,7 +918,8 @@ public class PacketSyncService {
 			}
 			for (String path : personaFilePaths) {
 				ResidentModel resident = ResidentModel.readPersona(path);
-				PersonaBiometricsAssembler.ensureAssembled(resident, null, contextKey);
+				PersonaBiometricsAssembler.ensureAssembled(resident,
+						PersonaBiometricsAssembler.hintsFromResident(resident), contextKey);
 				String packetPath = packetDir.toString() + File.separator + resident.getId();
 				RestClient.logInfo(contextKey, "packetPath=" + packetPath);
 				String returnMsg = packetTemplateProvider.generate("registration_client", process, resident, packetPath,

--- a/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PreregSyncService.java
+++ b/mosip-packet-creator/src/main/java/io/mosip/testrig/dslrig/packetcreator/service/PreregSyncService.java
@@ -49,7 +49,6 @@ public class PreregSyncService {
 		try{
 			workDirectory = Files.createTempDirectory("prereg").toFile().getAbsolutePath();
 			logger.info("CURRENT PRE_REG WORK DIRECTORY --> {}", workDirectory);
-			apiUtil.clearToken();
 		} catch(Exception ex){
 			logger.error("", ex);
 		}

--- a/mosipTestDataProvider/pom.xml
+++ b/mosipTestDataProvider/pom.xml
@@ -11,7 +11,13 @@
 	</properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
+		<testSourceDirectory>src/test/java</testSourceDirectory>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
@@ -68,23 +74,6 @@
 			<artifactId>generex</artifactId>
 			<version>1.0.2</version>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.codehaus.groovy/groovy-all -->
-		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-all</artifactId>
-			<version>3.0.7</version>
-			<type>pom</type>
-			<exclusions>
-				<exclusion>
-					<groupId>org.codehaus.groovy</groupId>
-					<artifactId>groovy</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.groovy</groupId>
-					<artifactId>groovy-xml</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
@@ -119,11 +108,6 @@
 			<version>68.1</version>
 		</dependency>
 		<dependency>
-			<groupId>info.cukes</groupId>
-			<artifactId>cucumber-java</artifactId>
-			<version>1.2.6</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
@@ -150,12 +134,6 @@
 			<groupId>io.cucumber</groupId>
 			<artifactId>gherkin</artifactId>
 			<version>15.0.2</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-java8 -->
-		<dependency>
-			<groupId>io.cucumber</groupId>
-			<artifactId>cucumber-java8</artifactId>
-			<version>6.9.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.json/json -->
 		<dependency>
@@ -277,10 +255,6 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-batch</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/BiometricDataProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/BiometricDataProvider.java
@@ -1422,7 +1422,7 @@ public class BiometricDataProvider {
 	}
 
 
-	static List<IrisDataModel> generateIris(int count, String contextKey) throws Exception {
+	public static List<IrisDataModel> generateIris(int count, String contextKey) throws Exception {
 		List<IrisDataModel> retVal = new ArrayList<IrisDataModel>();
 
 		IrisDataModel m = new IrisDataModel();

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PacketTemplateProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PacketTemplateProvider.java
@@ -128,7 +128,8 @@ public class PacketTemplateProvider {
 		String ridFolder = "";
 		Path path = Paths.get(rootFolder);
 		RestClient.logInfo(contextKey, "path1:" + path);
-		PersonaBiometricsAssembler.ensureAssembled(resident, null, contextKey);
+		PersonaBiometricsAssembler.ensureAssembled(resident,
+				PersonaBiometricsAssembler.hintsFromResident(resident), contextKey);
 		ContextSchemaDetail contextSchemaDetail = getSchema(contextKey);
 
 		if (!Files.exists(path)) {
@@ -265,6 +266,9 @@ public class PacketTemplateProvider {
 		for (MosipIDSchema s : contextSchemaDetail.getSchema()) {
 			if (!CommonUtil.isExists(contextSchemaDetail.getRequiredAttribs(), s.getId()))
 				continue;
+			if (s.getType().equalsIgnoreCase(DOCUMENTTYPE) || s.getType().equalsIgnoreCase(BIOMETRICSTYPE)) {
+				continue;
+			}
 			List<SchemaRule> rule = s.getRequiredOn();
 			if (rule != null) {
 				for (SchemaRule sr : rule) {
@@ -272,7 +276,6 @@ public class PacketTemplateProvider {
 					boolean bval = MosipMasterData.executeMVEL(sr.getExpr(), (Object) allIdentityDetails);
 					RestClient.logInfo(contextKey, "rule:result=" + bval);
 					if (!bval) {
-						json = new JSONObject(idJson);
 						json.put(s.getId(), JSONObject.NULL);
 					}
 				}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PacketTemplateProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PacketTemplateProvider.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import io.cucumber.core.gherkin.messages.internal.gherkin.internal.com.eclipsesource.json.Json;
+import io.mosip.testrig.dslrig.dataprovider.packet.PacketTemplateDocuments;
 import io.mosip.mock.sbi.exception.SBIException;
 import io.mosip.testrig.dslrig.dataprovider.models.BioModality;
 import io.mosip.testrig.dslrig.dataprovider.models.ContextSchemaDetail;
@@ -49,6 +49,7 @@ import io.mosip.testrig.dslrig.dataprovider.models.ResidentModel;
 import io.mosip.testrig.dslrig.dataprovider.models.SchemaRule;
 import io.mosip.testrig.dslrig.dataprovider.models.SchemaValidator;
 import io.mosip.testrig.dslrig.dataprovider.models.mds.MDSRCaptureModel;
+import io.mosip.testrig.dslrig.dataprovider.persona.PersonaBiometricsAssembler;
 import io.mosip.testrig.dslrig.dataprovider.preparation.MosipMasterData;
 import io.mosip.testrig.dslrig.dataprovider.test.CreatePersona;
 import io.mosip.testrig.dslrig.dataprovider.util.CommonUtil;
@@ -121,12 +122,13 @@ public class PacketTemplateProvider {
 	public String generate(String source, String process, ResidentModel resident, String packetFilePath,
 			String preregId, String machineId, String centerId, String contextKey, Properties props,
 			JSONObject preregResponse, String purpose, String qualityScore, boolean genarateValidCbeff)
-			throws IOException {
+			throws Exception {
 		final HashMap<String, String[]> fileInfo = new HashMap<String, String[]>();
 		String rootFolder = packetFilePath;
 		String ridFolder = "";
 		Path path = Paths.get(rootFolder);
 		RestClient.logInfo(contextKey, "path1:" + path);
+		PersonaBiometricsAssembler.ensureAssembled(resident, null, contextKey);
 		ContextSchemaDetail contextSchemaDetail = getSchema(contextKey);
 
 		if (!Files.exists(path)) {
@@ -243,7 +245,8 @@ public class PacketTemplateProvider {
 	private JSONObject processMVEL(ResidentModel resident, String idJson, String process,
 			ContextSchemaDetail contextSchemaDetail, String contextKey) {
 		Map<String, Object> allIdentityDetails = new LinkedHashMap<String, Object>();
-		Map<String, DocumentDto> documents = getDocuments(resident, idJson, contextSchemaDetail);
+		Map<String, DocumentDto> documents = PacketTemplateDocuments.buildDocumentMap(resident, idJson,
+				contextSchemaDetail);
 		allIdentityDetails.putAll(documents);
 		JSONObject json = new JSONObject(idJson);
 		json = json.getJSONObject(IDENTITY);
@@ -270,7 +273,7 @@ public class PacketTemplateProvider {
 					RestClient.logInfo(contextKey, "rule:result=" + bval);
 					if (!bval) {
 						json = new JSONObject(idJson);
-						json.put(s.getId(), Json.NULL);
+						json.put(s.getId(), JSONObject.NULL);
 					}
 				}
 			}
@@ -282,34 +285,6 @@ public class PacketTemplateProvider {
 			json = identityWrapper; 
 		}
 		return json;
-	}
-
-	private Map<String, DocumentDto> getDocuments(ResidentModel resident, String idJson,
-			ContextSchemaDetail contextSchemaDetail) {
-		Map<String, DocumentDto> documents = new HashMap<>();
-		JSONObject json = new JSONObject(idJson);
-		json = json.getJSONObject(IDENTITY);
-		for (MosipIDSchema s : contextSchemaDetail.getSchema()) {
-			if (!CommonUtil.isExists(contextSchemaDetail.getRequiredAttribs(), s.getId()))
-				continue;
-			for (MosipDocument doc : resident.getDocuments()) {
-				if (s.getSubType() != null
-						&& doc.getDocCategoryCode().toLowerCase().equals(s.getSubType().toLowerCase())) {
-					DocumentDto documentDto = new DocumentDto();
-					if (json.has(s.getId())) {
-						JSONObject formateJson = json.getJSONObject(s.getId());
-						documentDto.setCategory(doc.getDocCategoryCode());
-						documentDto.setFormat(formateJson.get(FORMAT).toString());
-						documentDto.setType(formateJson.get("type").toString());
-						documentDto.setValue(formateJson.get(VALUE).toString());
-						documents.put(s.getId(), documentDto);
-					}
-				}
-
-			}
-
-		}
-		return documents;
 	}
 
 	static Map<String, Object> getIdentityObject(List<MosipIDSchema> schemas, String process, double schemaVersion,
@@ -611,7 +586,7 @@ public class PacketTemplateProvider {
 		JSONObject o = new JSONObject();
 		o.put(LANGUAGE, primLang);
 		if (primValue != null && primValue.equals(""))
-			o.put(VALUE, Json.NULL);
+			o.put(VALUE, JSONObject.NULL);
 		else
 			o.put(VALUE, primValue);
 		ar.put(o);
@@ -620,7 +595,7 @@ public class PacketTemplateProvider {
 			o = new JSONObject();
 			o.put(LANGUAGE, secLang);
 			if (secValue != null && secValue.equals(""))
-				o.put(VALUE, Json.NULL);
+				o.put(VALUE, JSONObject.NULL);
 			else
 				o.put(VALUE, secValue);
 			ar.put(o);
@@ -629,7 +604,7 @@ public class PacketTemplateProvider {
 			o = new JSONObject();
 			o.put(LANGUAGE, thirdLang);
 			if (thirdValue.equals(""))
-				o.put(VALUE, Json.NULL);
+				o.put(VALUE, JSONObject.NULL);
 			else
 				o.put(VALUE, thirdValue);
 			ar.put(o);
@@ -658,7 +633,7 @@ public class PacketTemplateProvider {
 		JSONObject o = new JSONObject();
 		o.put(LANGUAGE, primLang);
 		if (primValue != null && primValue.equals(""))
-			o.put(VALUE, Json.NULL);
+			o.put(VALUE, JSONObject.NULL);
 		else
 			o.put(VALUE, primValue);
 		ar.put(o);
@@ -667,7 +642,7 @@ public class PacketTemplateProvider {
 			o = new JSONObject();
 			o.put(LANGUAGE, secLang);
 			if (secValue != null && secValue.equals(""))
-				o.put(VALUE, Json.NULL);
+				o.put(VALUE, JSONObject.NULL);
 			else
 				o.put(VALUE, secValue);
 			ar.put(o);
@@ -676,7 +651,7 @@ public class PacketTemplateProvider {
 			o = new JSONObject();
 			o.put(LANGUAGE, thirdLang);
 			if (thirdValue.equals(""))
-				o.put(VALUE, Json.NULL);
+				o.put(VALUE, JSONObject.NULL);
 			else
 				o.put(VALUE, thirdValue);
 			ar.put(o);

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PhotoProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/PhotoProvider.java
@@ -34,7 +34,7 @@ public class PhotoProvider {
 		return getPhoto(contextKey, generateLargeFace, false);
 	}
 
-	static byte[][] getPhoto(String contextKey, boolean generateLargeFace, boolean generateObstructedFace) {
+	public static byte[][] getPhoto(String contextKey, boolean generateLargeFace, boolean generateObstructedFace) {
 
 		byte[] bencoded = null;
 		byte[] bData = null;

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/ResidentDataProvider.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/ResidentDataProvider.java
@@ -1,50 +1,27 @@
 package io.mosip.testrig.dslrig.dataprovider;
 
-import java.io.IOException;
-import java.security.SecureRandom;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.lowagie.text.DocumentException;
-
 import io.mosip.testrig.dslrig.dataprovider.mds.MDSClient;
-import io.mosip.testrig.dslrig.dataprovider.models.ApplicationConfigIdSchema;
 import io.mosip.testrig.dslrig.dataprovider.models.BiometricDataModel;
-import io.mosip.testrig.dslrig.dataprovider.models.Contact;
-import io.mosip.testrig.dslrig.dataprovider.models.DynamicFieldModel;
-import io.mosip.testrig.dslrig.dataprovider.models.DynamicFieldValueModel;
 import io.mosip.testrig.dslrig.dataprovider.models.IrisDataModel;
-import io.mosip.testrig.dslrig.dataprovider.models.MosipDocument;
-import io.mosip.testrig.dslrig.dataprovider.models.MosipGenderModel;
-import io.mosip.testrig.dslrig.dataprovider.models.MosipIndividualTypeModel;
-import io.mosip.testrig.dslrig.dataprovider.models.MosipLanguage;
-import io.mosip.testrig.dslrig.dataprovider.models.MosipPreRegLoginConfig;
-import io.mosip.testrig.dslrig.dataprovider.models.Name;
-import io.mosip.testrig.dslrig.dataprovider.models.NrcId;
 import io.mosip.testrig.dslrig.dataprovider.models.ResidentModel;
-import io.mosip.testrig.dslrig.dataprovider.preparation.MosipMasterData;
+import io.mosip.testrig.dslrig.dataprovider.persona.PersonaBiometricsAssembler;
+import io.mosip.testrig.dslrig.dataprovider.persona.PersonaDemographicsBuilder;
 import io.mosip.testrig.dslrig.dataprovider.util.CommonUtil;
-import io.mosip.testrig.dslrig.dataprovider.util.DataProviderConstants;
 import io.mosip.testrig.dslrig.dataprovider.util.Gender;
 import io.mosip.testrig.dslrig.dataprovider.util.ResidentAttribute;
-import io.mosip.testrig.dslrig.dataprovider.util.RestClient;
-import io.mosip.testrig.dslrig.dataprovider.util.Translator;
-import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
 
 
 public class ResidentDataProvider {
 	private static final Logger logger = LoggerFactory.getLogger(ResidentDataProvider.class);
-	private static SecureRandom  rand = new SecureRandom ();
 	private static final Set<String> SINGLE_FINGER_TYPES = Set.of(
 	        "rightindex",
 	        "rightlittle",
@@ -58,35 +35,34 @@ public class ResidentDataProvider {
 	        "rightthumb"
 	);
 
-		Properties attributeList;
+	Properties attributeList;
 
 
 	public ResidentDataProvider() {
 		attributeList = new Properties();
-
-
-		RestClient.clearToken();
 	}
 
 	public ResidentDataProvider addCondition(ResidentAttribute attributeName, Object attributeValue) {
 		attributeList.put(attributeName, attributeValue);
 		return this;
 	}
-	public static ResidentModel genGuardian(Properties attributes,String contextKey) throws Exception {
+
+	public static ResidentModel genGuardian(Properties attributes, String contextKey) throws Exception {
 		Properties attributeList = new Properties();
-		attributes.forEach( (k,v) ->{
-			attributeList.put(k, v);
-		});
+		attributes.forEach((k, v) -> attributeList.put(k, v));
 
 		attributeList.put(ResidentAttribute.RA_Age, ResidentAttribute.RA_Adult);
 		attributeList.put(ResidentAttribute.RA_Gender, Gender.Any);
 
 		ResidentDataProvider provider = new ResidentDataProvider();
 		provider.attributeList = attributeList;
-		ResidentModel guardian = provider.generate(contextKey).get(0);
-		return guardian;
+		return provider.generate(contextKey).get(0);
 	}
-	public static ResidentModel updateBiometric(ResidentModel model,String bioType,String contextKey) throws Exception {
+
+	public static ResidentModel updateBiometric(ResidentModel model, String bioType, String contextKey)
+			throws Exception {
+		PersonaBiometricsAssembler.ensureAssembled(model, PersonaBiometricsAssembler.hintsFromResident(model),
+				contextKey);
 		boolean bDirty = false;
 		model.setFilteredBioAttribtures(null);
 		if (bioType.equalsIgnoreCase("finger")) {
@@ -97,7 +73,7 @@ public class ResidentDataProvider {
 			model.setSkipFinger(false);
 			bDirty = true;
 		} else if (SINGLE_FINGER_TYPES.contains(bioType.toLowerCase())) {
-			BiometricDataModel bioData = BiometricDataProvider.updateSelectedFingerData(model ,contextKey, bioType);
+			BiometricDataModel bioData = BiometricDataProvider.updateSelectedFingerData(model, contextKey, bioType);
 			model.getBiometric().setFingerPrint(bioData.getFingerPrint());
 			model.getBiometric().setFingerHash(bioData.getFingerHash());
 			model.getBiometric().setFingerRaw(bioData.getFingerRaw());
@@ -121,24 +97,25 @@ public class ResidentDataProvider {
 			}
 		}
 
-		if(bioType.equalsIgnoreCase("face")) {
+		if (bioType.equalsIgnoreCase("face")) {
 			BiometricDataModel bioData = model.getBiometric();
 			byte[][] faceData = BiometricDataProvider.updateFaceData(contextKey);
-			bioData.setEncodedPhoto(
-					Base64.getEncoder().encodeToString(faceData[0]));
+			bioData.setEncodedPhoto(Base64.getEncoder().encodeToString(faceData[0]));
 			bioData.setRawFaceData(faceData[1]);
-
-			bioData.setFaceHash(CommonUtil.getHexEncodedHash( faceData[1]));
+			bioData.setFaceHash(CommonUtil.getHexEncodedHash(faceData[1]));
 			bDirty = true;
 		}
 
-		  if(bDirty) model.getBiometric().setCbeff(null);
+		if (bDirty) {
+			model.getBiometric().setCbeff(null);
+		}
 
 		return model;
 	}
 
 	public static ResidentModel updateBiometricWithTestPersona(ResidentModel model, ResidentModel testModel,
 			String bioType, String contextKey) throws Exception {
+		PersonaBiometricsAssembler.ensureBiometricShell(model);
 		model.setFilteredBioAttribtures(null);
 		boolean bDirty = false;
 		if (bioType.equalsIgnoreCase("finger")) {
@@ -157,398 +134,24 @@ public class ResidentDataProvider {
 			model.getBiometric().setRawFaceData(testModel.getBiometric().getRawFaceData());
 			bDirty = true;
 		}
-		 if(bDirty) {
-			 model.setFilteredBioAttribtures(null);
-			 model.getBiometric().setCbeff(null);
-		 }
+		if (bDirty) {
+			model.setFilteredBioAttribtures(null);
+			model.getBiometric().setCbeff(null);
+		}
 		return model;
 	}
 
-	private static String[] getConfiguredLanguages(String contextKey) {
-		String [] lang_arr = null;
-		List<String> langs= new ArrayList<String>();
-		List<MosipLanguage> allLang = null;
-		try {
-			allLang = MosipMasterData.getConfiguredLanguages(contextKey);
-		}catch(Exception e) {
-			logger.error(e.getMessage());
-		}
-
-		MosipPreRegLoginConfig  preregconfig = MosipMasterData.getPreregLoginConfig(contextKey);
-		if(preregconfig == null) {
-
-			try {
-
-				lang_arr = new String[allLang.size()];
-				int i=0;
-				for(MosipLanguage l: allLang){
-					lang_arr[i]= l.getIso2();
-					i++;
-				}
-			}catch(Exception e) {
-				logger.error(e.getMessage());
-			}
-			return lang_arr;
-		}
-
-		String primary_lang = preregconfig.getMosip_primary_language();
-		if(primary_lang != null)
-			langs.add(primary_lang);
-
-
-		String mandatory_languages_list =preregconfig.getMandatory_languages();
-		 String[] mandatlangueages = null;
-		if(mandatory_languages_list !=null && !mandatory_languages_list.equals("")) {
-			  mandatlangueages = mandatory_languages_list.split(",");
-		}
-		int minLanguages=Integer.parseInt(preregconfig.getMin_languages_count());
-		String opt_lang_list = preregconfig.getOptional_languages();
-		String[] opt_langs = null;
-		if(opt_lang_list != null && !opt_lang_list.equals("")) {
-			opt_langs = opt_lang_list.split(",");
-		}
-		if(mandatlangueages != null && mandatlangueages.length > 0 ) {
-			for(int i=0; i < mandatlangueages.length; i++)
-				langs.add( mandatlangueages[i]);
-		}
-		if(opt_langs != null && opt_langs.length >0) {
-			for(int i=0; i < opt_langs.length; i++)
-				langs.add( opt_langs[i]);
-		}
-
-		if(minLanguages > 0  && langs.size() < minLanguages && allLang != null ) {
-			int n2add = minLanguages - langs.size();
-			for(int i= 0; i < allLang.size() && i < n2add; i++ ) {
-				langs.add( allLang.get(i).getIso2());
-			}
-		}
-		lang_arr = new String [ minLanguages > 0 ? minLanguages : langs.size()];
-		return langs.toArray(lang_arr);
-	}
-
-
 	public List<ResidentModel> generate(String contextKey) throws Exception {
+		List<ResidentModel> residents = new ArrayList<>();
+		boolean lazyBiometrics = PersonaBiometricsAssembler.isLazyEnabled(contextKey);
+		PersonaDemographicsBuilder.Context demoCtx = PersonaDemographicsBuilder.prepare(attributeList, contextKey);
 
-		List<ResidentModel> residents = new ArrayList<ResidentModel>();
-
-		int count = 1;
-		Gender gender =  (Gender) attributeList.get(ResidentAttribute.RA_Gender);
-		String primary_lang = (String) attributeList.get(ResidentAttribute.RA_PRIMARAY_LANG);
-		String sec_lang = (String) attributeList.get(ResidentAttribute.RA_SECONDARY_LANG);
-		String override_primary_lan = primary_lang;
-		String override_sec_lang = sec_lang;
-		String third_lang = (String) attributeList.get(ResidentAttribute.RA_THIRD_LANG);
-
-		Object oAttr = attributeList.get(ResidentAttribute.RA_SCHEMA_VERSION);
-		double schemaVersion = (oAttr == null) ? 0: (double)oAttr;
-		VariableManager.setVariableValue(contextKey,"schemaVersion", schemaVersion);
-
-
-		String[] langsRequired = getConfiguredLanguages(contextKey);
-		if(langsRequired != null) {
-			primary_lang = langsRequired[0];
-			if(langsRequired.length > 1)
-				sec_lang = langsRequired[1];
-			if(langsRequired.length > 2)
-				third_lang = langsRequired[2];
-
-		}
-
-
-		if(override_primary_lan != null && !override_primary_lan.equals(""))
-			primary_lang = override_primary_lan;
-
-		if(override_sec_lang != null && !override_sec_lang.equals(""))
-			sec_lang = override_sec_lang;
-
-		oAttr = attributeList.get(ResidentAttribute.RA_Iris);
-		boolean bIrisRequired = true;
-
-		if(oAttr != null) {
-			bIrisRequired = (boolean)oAttr;
-		}
-		if(gender == null)
-			gender  = Gender.Any;
-		List<Name> names_sec = null;
-		List<Name> names_primary =null;
-
-		Hashtable<String,List<DynamicFieldModel>> dynaFields = MosipMasterData.getAllDynamicFields(contextKey);
-
-		List<MosipGenderModel> genderTypes_primary = MosipMasterData.getGenderTypes(primary_lang,contextKey);
-		List<MosipGenderModel> genderTypes_sec = null;
-		List<MosipGenderModel> genderTypes_third = null;
-
-		if(sec_lang != null)
-			genderTypes_sec = MosipMasterData.getGenderTypes(sec_lang,contextKey);
-
-		if(third_lang != null)
-			genderTypes_third = MosipMasterData.getGenderTypes(third_lang,contextKey);
-
-
-		int maleCount =0,femaleCount = 0;
-
-		switch(gender) {
-			case  Any:
-				maleCount = count/2;
-				femaleCount = count-maleCount;
-				break;
-			case Male:
-				maleCount = count;
-				break;
-			case Female:
-				femaleCount = count;
-				break;
-			default:
-				break;
-
-		}
-		List<Name> eng_male_names = null;
-		List<Name> eng_female_names = null;
-		List<Name> eng_names = null;
-
-		if(maleCount >0) {
-			eng_male_names = NameProvider.generateNames(Gender.Male,  DataProviderConstants.LANG_CODE_ENGLISH, maleCount, null,contextKey);
-			eng_names = eng_male_names;
-		}
-		if(femaleCount > 0) {
-			eng_female_names = NameProvider.generateNames(Gender.Female,  DataProviderConstants.LANG_CODE_ENGLISH, femaleCount, null,contextKey);
-			if(eng_names != null)
-				eng_names.addAll(eng_female_names);
-			else
-				eng_names = eng_female_names;
-		}
-
-		if(primary_lang != null) {
-			if(!primary_lang.startsWith( DataProviderConstants.LANG_CODE_ENGLISH)) {
-				names_primary = NameProvider.generateNames(gender, primary_lang, count, eng_names,contextKey);
-			}
-			else
-				names_primary = eng_names;
-
-		}
-		if(sec_lang != null) {
-			if(!sec_lang.startsWith( DataProviderConstants.LANG_CODE_ENGLISH)) {
-				names_sec = NameProvider.generateNames(gender, sec_lang, count, eng_names,contextKey);
-			}
-			else
-				names_sec = eng_names;
-
-		}
-
-		List<Contact> contacts = ContactProvider.generate(eng_names, count);
-		List<NrcId> nrcIds = NrcIdProvider.generate( count);
-		ApplicationConfigIdSchema locations = LocationProvider.generate(primary_lang, count,contextKey);
-		ApplicationConfigIdSchema locations_secLang  = null;
-		if(sec_lang != null)
-			locations_secLang = LocationProvider.generate(sec_lang, count, contextKey);
-
-		Hashtable<String,List<DynamicFieldValueModel>> bloodGroups = null;
-		if(dynaFields != null && !dynaFields.isEmpty())
-			 bloodGroups = BloodGroupProvider.generate(count, dynaFields);
-
-		Hashtable<String, List<MosipIndividualTypeModel>> resStatusList =  MosipMasterData.getIndividualTypes(contextKey);
-
-
-		List<IrisDataModel> irisList = null;
-		try {
-			if(bIrisRequired)
-				irisList = BiometricDataProvider.generateIris(count,contextKey);
-		} catch (  Exception e1) {
-			logger.error(e1.getMessage());
-		}
-
-
-		for(int i=0; i < count; i++) {
-			Gender res_gender = names_primary.get(i).getGender();
-			ResidentModel res= new ResidentModel();
-			res.setPrimaryLanguage(primary_lang);
-			res.setSecondaryLanguage(sec_lang);
-			res.setDynaFields(dynaFields);
-			res.setName(names_primary.get(i));
-			res.setThirdLanguage(third_lang);
-
-			res.getGenderTypes().put(primary_lang, genderTypes_primary);
-			if(sec_lang != null)
-				res.getGenderTypes().put(sec_lang, genderTypes_sec);
-			if(third_lang != null)
-				res.getGenderTypes().put(third_lang, genderTypes_third);
-
-			if(attributeList.containsKey(ResidentAttribute.RA_MissList)) {
-				res.setMissAttributes( (List<String>) attributeList.get(ResidentAttribute.RA_MissList));
-			}
-			if(attributeList.containsKey(ResidentAttribute.RA_InvalidList)) {
-				res.setInvalidAttributes( (List<String>) attributeList.get(ResidentAttribute.RA_InvalidList));
-			}
-			res.setGender(res_gender);
-			if(names_sec != null) {
-				res.setName_seclang(names_sec.get(i));
-			}
-
-			if(bloodGroups != null && !bloodGroups.isEmpty())
-				res.setBloodgroup(bloodGroups.get(res.getPrimaryLanguage()).get(i));
-			res.setContact(contacts.get(i));
-			res.setNrcId(nrcIds.get(i));
-			res.setDob( DateOfBirthProvider.generate((ResidentAttribute) attributeList.get(ResidentAttribute.RA_Age),contextKey));
-			ResidentAttribute age =  (ResidentAttribute) attributeList.get(ResidentAttribute.RA_Age);
-			Boolean skipGaurdian = false;
-			if(age == ResidentAttribute.RA_Minor)  {
-				res.setMinor(true);
-				if(attributeList.containsKey(ResidentAttribute.RA_SKipGaurdian))
-					skipGaurdian =   Boolean.valueOf(attributeList.get(ResidentAttribute.RA_SKipGaurdian).toString());
-				if(!skipGaurdian)
-					res.setGuardian( genGuardian(attributeList, contextKey));
-			}
-
-			else if(age == ResidentAttribute.RA_Infant )  {
-				res.setInfant(true);
-				if(attributeList.containsKey(ResidentAttribute.RA_SKipGaurdian))
-					skipGaurdian =   Boolean.valueOf(attributeList.get(ResidentAttribute.RA_SKipGaurdian).toString());
-				if(!skipGaurdian)
-					res.setGuardian( genGuardian(attributeList, contextKey));
-			}
-
-			res.setAppConfigIdSchema( locations);
-			res.setAppConfigIdSchema_secLang(locations_secLang);
-
-			res.setLocation(  locations.getTblLocations().get(i));
-			String [] addr = new String[ DataProviderConstants.MAX_ADDRESS_LINES];
-			String addrFmt = "#%d, %d Street, %d block, lane #%d" ;
-			for(int ii=0; ii< DataProviderConstants.MAX_ADDRESS_LINES; ii++) {
-				String addrLine = String.format(addrFmt, (10+ rand.nextInt(999)),
-					(1 + rand.nextInt(99)),
-					(1 + rand.nextInt(10)), ii+1
-					);
-				addr[ii] = addrLine;
-			}
-
-			String primLang = res.getPrimaryLanguage();
-			if(!primLang.toLowerCase().startsWith("en"))
-			{
-
-				String [] addrP = new String[ DataProviderConstants.MAX_ADDRESS_LINES];
-
-				for(int ii=0; ii< DataProviderConstants.MAX_ADDRESS_LINES; ii++) {
-
-					addrP[ii] = Translator.translate(primLang, addr[ii],contextKey);
-				}
-				res.setAddress(addrP);
-			}
-			else
-				res.setAddress(addr);
-
-			if(res.getSecondaryLanguage() != null) {
-				res.setLocation_seclang (  locations_secLang.getTblLocations().get(i));
-				String[] addr_sec = new String[DataProviderConstants.MAX_ADDRESS_LINES];
-				for(int ii=0; ii< DataProviderConstants.MAX_ADDRESS_LINES; ii++) {
-					addr_sec[ii] = Translator.translate(res.getSecondaryLanguage(), addr[ii],contextKey);
-				}	
-				res.setAddress_seclang(addr_sec);
-			}
-
-
-			List<MosipIndividualTypeModel> lstResStatusPrimLang = resStatusList.get( res.getPrimaryLanguage());
-			int indx =0;
-			if(lstResStatusPrimLang != null) {
-				for(MosipIndividualTypeModel itm: lstResStatusPrimLang) {
-					if(itm.getCode().equals("NFR")) {
-						res.setResidentStatus(itm);
-						break;
-					}
-					indx++;
-				}
-				if(res.getResidentStatus() == null) {
-					indx = rand.nextInt(lstResStatusPrimLang.size());
-					res.setResidentStatus(lstResStatusPrimLang.get(indx));
-				}
-			}
-			if(res.getSecondaryLanguage() != null) {
-				List<MosipIndividualTypeModel> lstResStatusSecLang = resStatusList.get( res.getSecondaryLanguage());
-				if(lstResStatusSecLang != null) {
-					for(MosipIndividualTypeModel itm: lstResStatusSecLang) {
-						if(itm.getCode().equals(lstResStatusPrimLang.get(indx).getCode())){
-							res.setResidentStatus_seclang(itm);
-							break;
-						}
-					}
-				}	
-				if(res.getResidentStatus_seclang() == null) {
-					res.setResidentStatus_seclang(res.getResidentStatus());
-				}
-			}
-			Object bFinger = attributeList.get(ResidentAttribute.RA_Finger);
-			Boolean skip =  (bFinger == null ? false: !(Boolean)bFinger);
-			res.setSkipFinger(skip);
-			bFinger = attributeList.get(ResidentAttribute.RA_Photo);
-			skip =  (bFinger == null ? false: !(Boolean)bFinger);
-			res.setSkipFace(skip);
-			bFinger = attributeList.get(ResidentAttribute.RA_Iris);
-			skip =  (bFinger == null ? false: !(Boolean)bFinger);
-			res.setSkipIris(skip);
-
-
-			BiometricDataModel bioData =null;
-			try {
-				bioData = BiometricDataProvider.getBiometricData(bFinger == null ? true: (Boolean)bFinger,contextKey);
-			} catch (Exception e2) {
-				logger.error(e2.getMessage());
-				throw e2;
-			}
-			if(bIrisRequired)
-				bioData.setIris(irisList.get(i));
-
-			Object bOFace = attributeList.get(ResidentAttribute.RA_Photo);
-			boolean bFace = ( bOFace == null ? true: (boolean)bOFace);
-			if(bFace) {
-
-				Object largeFaceFlag = attributeList.get(ResidentAttribute.RA_LargeFace);
-				boolean generateLargeFace = largeFaceFlag != null && Boolean.parseBoolean(largeFaceFlag.toString());
-				Object obstructedFaceFlag = attributeList.get(ResidentAttribute.RA_ObstructedFace);
-				boolean generateObstructedFace = obstructedFaceFlag != null
-						&& Boolean.parseBoolean(obstructedFaceFlag.toString());
-
-				byte[][] faceData = PhotoProvider.getPhoto(contextKey, generateLargeFace, generateObstructedFace);
-
-				bioData.setEncodedPhoto(
-						Base64.getEncoder().encodeToString(faceData[0]));
-				bioData.setRawFaceData(faceData[1]);
-
-				try {
-					bioData.setFaceHash(CommonUtil.getHexEncodedHash( faceData[1]));
-				} catch (Exception e1) {
-
-				}
-			}
-
-
-			res.setBiometric(bioData);
-
-			oAttr = attributeList.get(ResidentAttribute.RA_Document);
-			boolean bDocRequired = ( oAttr == null ? true: (boolean)oAttr);
-
-			if(bDocRequired) {
-				try {
-					Object lowQualityDocumentAttr = attributeList.get(ResidentAttribute.RA_LowQualityDocument);
-					boolean generateLowQualityDocuments = lowQualityDocumentAttr != null
-							&& Boolean.parseBoolean(lowQualityDocumentAttr.toString());
-					res.setDocuments(DocumentProvider.generateDocuments(res, contextKey, generateLowQualityDocuments));
-					Object docCategoryAttr = attributeList.get(ResidentAttribute.RA_DocumentCategory);
-					if (docCategoryAttr != null && !docCategoryAttr.toString().trim().isEmpty()) {
-						String requiredDocCategory = docCategoryAttr.toString().trim();
-						res.setDocuments(res.getDocuments().stream()
-								.filter(doc -> doc != null && doc.getDocCategoryCode() != null
-										&& doc.getDocCategoryCode().equalsIgnoreCase(requiredDocCategory))
-								.collect(Collectors.toList()));
-					}
-				} catch (DocumentException | IOException  | ParseException e) {
-
-					logger.error(e.getMessage());
-				}
-			}
-
-			for(MosipDocument doc: res.getDocuments()) {
-				String id = doc.getDocCategoryCode();
-				int index = CommonUtil.generateRandomNumbers(1, doc.getDocs().size()-1, 0)[0];
-				res.getDocIndexes().put(id,index);
+		for (int i = 0; i < demoCtx.count; i++) {
+			ResidentModel res = PersonaDemographicsBuilder.populate(i, demoCtx, attributeList, contextKey);
+			if (lazyBiometrics) {
+				PersonaBiometricsAssembler.markDeferred(res, attributeList);
+			} else {
+				PersonaBiometricsAssembler.assemble(res, attributeList, contextKey);
 			}
 			residents.add(res);
 		}
@@ -556,22 +159,22 @@ public class ResidentDataProvider {
 	}
 
 	public static void main(String[] args) throws Exception {
-
 		ResidentDataProvider residentProvider = new ResidentDataProvider();
 		residentProvider
-		.addCondition(ResidentAttribute.RA_SECONDARY_LANG, "ara")
-		.addCondition(ResidentAttribute.RA_Gender, Gender.Any)
-		.addCondition(ResidentAttribute.RA_Age, ResidentAttribute.RA_Adult);
+				.addCondition(ResidentAttribute.RA_SECONDARY_LANG, "ara")
+				.addCondition(ResidentAttribute.RA_Gender, Gender.Any)
+				.addCondition(ResidentAttribute.RA_Age, ResidentAttribute.RA_Adult);
 
-		List<ResidentModel> lst =  residentProvider.generate("contextKey");
+		List<ResidentModel> lst = residentProvider.generate("contextKey");
+		for (ResidentModel r : lst) {
+			PersonaBiometricsAssembler.ensureAssembled(r, null, "contextKey");
+		}
 		MDSClient cli = new MDSClient(0);
 
-		for(ResidentModel r: lst) {
+		for (ResidentModel r : lst) {
 			logger.info(r.toJSONString());
-
-			cli.createProfile("C:\\Mosip.io\\gitrepos\\mosip-mock-services\\MockMDS\\target\\Profile\\", "tst1", r,"contextKey","Registration");
-
+			cli.createProfile("C:\\Mosip.io\\gitrepos\\mosip-mock-services\\MockMDS\\target\\Profile\\", "tst1", r,
+					"contextKey", "Registration");
 		}
-
 	}
 }

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/packet/PacketTemplateDocuments.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/packet/PacketTemplateDocuments.java
@@ -1,0 +1,56 @@
+package io.mosip.testrig.dslrig.dataprovider.packet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONObject;
+
+import io.mosip.testrig.dslrig.dataprovider.models.ContextSchemaDetail;
+import io.mosip.testrig.dslrig.dataprovider.models.DocumentDto;
+import io.mosip.testrig.dslrig.dataprovider.models.MosipDocument;
+import io.mosip.testrig.dslrig.dataprovider.models.MosipIDSchema;
+import io.mosip.testrig.dslrig.dataprovider.models.ResidentModel;
+import io.mosip.testrig.dslrig.dataprovider.util.CommonUtil;
+
+/**
+ * Document field mapping for packet ID JSON (extracted from {@code PacketTemplateProvider}).
+ */
+public final class PacketTemplateDocuments {
+
+	private static final String IDENTITY = "identity";
+	private static final String FORMAT = "format";
+	private static final String VALUE = "value";
+
+	private PacketTemplateDocuments() {
+	}
+
+	public static Map<String, DocumentDto> buildDocumentMap(ResidentModel resident, String idJson,
+			ContextSchemaDetail contextSchemaDetail) {
+		Map<String, DocumentDto> documents = new HashMap<>();
+		if (resident.getDocuments() == null) {
+			return documents;
+		}
+		JSONObject json = new JSONObject(idJson);
+		json = json.getJSONObject(IDENTITY);
+		for (MosipIDSchema s : contextSchemaDetail.getSchema()) {
+			if (!CommonUtil.isExists(contextSchemaDetail.getRequiredAttribs(), s.getId())) {
+				continue;
+			}
+			for (MosipDocument doc : resident.getDocuments()) {
+				if (s.getSubType() != null
+						&& doc.getDocCategoryCode().equalsIgnoreCase(s.getSubType())) {
+					if (json.has(s.getId())) {
+						JSONObject formateJson = json.getJSONObject(s.getId());
+						DocumentDto documentDto = new DocumentDto();
+						documentDto.setCategory(doc.getDocCategoryCode());
+						documentDto.setFormat(formateJson.get(FORMAT).toString());
+						documentDto.setType(formateJson.get("type").toString());
+						documentDto.setValue(formateJson.get(VALUE).toString());
+						documents.put(s.getId(), documentDto);
+					}
+				}
+			}
+		}
+		return documents;
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaBiometricsAssembler.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaBiometricsAssembler.java
@@ -74,11 +74,11 @@ public final class PersonaBiometricsAssembler {
 		if (attrs != null && "true".equals(attrs.get(ATTR_ASSEMBLED))) {
 			return false;
 		}
-		if (resident.getBiometric() != null && resident.getBiometric().getFingerPrint() != null) {
-			return false;
-		}
 		if (attrs != null && "true".equals(attrs.get(ATTR_DEFERRED))) {
 			return true;
+		}
+		if (resident.getBiometric() != null && resident.getBiometric().getFingerPrint() != null) {
+			return false;
 		}
 		return resident.getBiometric() == null;
 	}
@@ -165,6 +165,7 @@ public final class PersonaBiometricsAssembler {
 
 		oAttr = attributeList.get(ResidentAttribute.RA_Document);
 		boolean bDocRequired = oAttr == null || Boolean.parseBoolean(oAttr.toString());
+		boolean documentsReady = true;
 		if (bDocRequired) {
 			try {
 				Object lowQualityDocumentAttr = attributeList.get(ResidentAttribute.RA_LowQualityDocument);
@@ -181,8 +182,15 @@ public final class PersonaBiometricsAssembler {
 							.collect(Collectors.toList()));
 				}
 			} catch (DocumentException | IOException | ParseException e) {
-				logger.error(e.getMessage());
+				logger.error("Document generation failed: {}", e.getMessage());
+				documentsReady = false;
 			}
+		}
+		if (bDocRequired && !documentsReady) {
+			Hashtable<String, String> attrs = resident.getAddtionalAttributes();
+			attrs.put(ATTR_DEFERRED, "true");
+			attrs.remove(ATTR_ASSEMBLED);
+			return;
 		}
 
 		if (resident.getDocuments() != null) {

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaBiometricsAssembler.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaBiometricsAssembler.java
@@ -1,0 +1,251 @@
+package io.mosip.testrig.dslrig.dataprovider.persona;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Base64;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.lowagie.text.DocumentException;
+
+import io.mosip.testrig.dslrig.dataprovider.BiometricDataProvider;
+import io.mosip.testrig.dslrig.dataprovider.DocumentProvider;
+import io.mosip.testrig.dslrig.dataprovider.PhotoProvider;
+import io.mosip.testrig.dslrig.dataprovider.models.BiometricDataModel;
+import io.mosip.testrig.dslrig.dataprovider.models.IrisDataModel;
+import io.mosip.testrig.dslrig.dataprovider.models.MosipDocument;
+import io.mosip.testrig.dslrig.dataprovider.models.ResidentModel;
+import io.mosip.testrig.dslrig.dataprovider.util.CommonUtil;
+import io.mosip.testrig.dslrig.dataprovider.util.ResidentAttribute;
+import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
+
+/**
+ * Finger/iris/face capture, documents, and doc indexes — deferred off the demographics hot path
+ * until packet template generation (or explicit assembly).
+ */
+public final class PersonaBiometricsAssembler {
+
+	private static final Logger logger = LoggerFactory.getLogger(PersonaBiometricsAssembler.class);
+
+	public static final String ATTR_DEFERRED = "biometricsDeferred";
+	public static final String ATTR_ASSEMBLED = "biometricsAssembled";
+	private static final String HINT_PREFIX = "assembly.";
+
+	private PersonaBiometricsAssembler() {
+	}
+
+	public static boolean isLazyEnabled(String contextKey) {
+		try {
+			Object perContext = VariableManager.getVariableValue(contextKey, "lazyPersonaBiometrics");
+			if (perContext != null) {
+				return Boolean.parseBoolean(perContext.toString());
+			}
+		} catch (Exception ignored) {
+			// fall through
+		}
+		try {
+			Object global = VariableManager.getVariableValue(VariableManager.NS_DEFAULT, "lazyPersonaBiometrics");
+			if (global != null) {
+				return Boolean.parseBoolean(global.toString());
+			}
+		} catch (Exception ignored) {
+			// default on for throughput
+		}
+		return true;
+	}
+
+	public static void markDeferred(ResidentModel resident, Properties attributeList) {
+		storeAssemblyHints(resident, attributeList);
+		Hashtable<String, String> attrs = resident.getAddtionalAttributes();
+		attrs.put(ATTR_DEFERRED, "true");
+		attrs.remove(ATTR_ASSEMBLED);
+	}
+
+	public static boolean needsAssembly(ResidentModel resident) {
+		if (resident == null) {
+			return false;
+		}
+		Hashtable<String, String> attrs = resident.getAddtionalAttributes();
+		if (attrs != null && "true".equals(attrs.get(ATTR_ASSEMBLED))) {
+			return false;
+		}
+		if (resident.getBiometric() != null && resident.getBiometric().getFingerPrint() != null) {
+			return false;
+		}
+		if (attrs != null && "true".equals(attrs.get(ATTR_DEFERRED))) {
+			return true;
+		}
+		return resident.getBiometric() == null;
+	}
+
+	public static void ensureAssembled(ResidentModel resident, Properties attributeList, String contextKey)
+			throws Exception {
+		if (resident == null || !needsAssembly(resident)) {
+			assembleGuardianIfNeeded(resident, attributeList, contextKey);
+			return;
+		}
+		Properties attrs = attributeList != null ? attributeList : hintsFromResident(resident);
+		assemble(resident, attrs, contextKey);
+		assembleGuardianIfNeeded(resident, attrs, contextKey);
+	}
+
+	private static void assembleGuardianIfNeeded(ResidentModel resident, Properties attributeList, String contextKey)
+			throws Exception {
+		if (resident == null || resident.getGuardian() == null) {
+			return;
+		}
+		ensureAssembled(resident.getGuardian(), attributeList, contextKey);
+	}
+
+	public static void assemble(ResidentModel resident, Properties attributeList, String contextKey) throws Exception {
+		if (resident == null || attributeList == null) {
+			return;
+		}
+
+		Object oAttr = attributeList.get(ResidentAttribute.RA_Iris);
+		boolean bIrisRequired = oAttr == null || Boolean.parseBoolean(oAttr.toString());
+
+		Object bFinger = attributeList.get(ResidentAttribute.RA_Finger);
+		Boolean skipFinger = bFinger == null ? false : !(Boolean) bFinger;
+		resident.setSkipFinger(skipFinger);
+
+		Object bPhoto = attributeList.get(ResidentAttribute.RA_Photo);
+		Boolean skipFace = bPhoto == null ? false : !(Boolean) bPhoto;
+		resident.setSkipFace(skipFace);
+
+		Object bIris = attributeList.get(ResidentAttribute.RA_Iris);
+		Boolean skipIris = bIris == null ? false : !(Boolean) bIris;
+		resident.setSkipIris(skipIris);
+
+		boolean fingerCapture = bFinger == null || Boolean.TRUE.equals(bFinger);
+		BiometricDataModel bioData;
+		try {
+			bioData = BiometricDataProvider.getBiometricData(fingerCapture, contextKey);
+		} catch (Exception e) {
+			logger.error(e.getMessage());
+			throw e;
+		}
+
+		if (bIrisRequired && !Boolean.TRUE.equals(skipIris)) {
+			try {
+				List<IrisDataModel> irisList = BiometricDataProvider.generateIris(1, contextKey);
+				if (irisList != null && !irisList.isEmpty()) {
+					bioData.setIris(irisList.get(0));
+				}
+			} catch (Exception e) {
+				logger.error(e.getMessage());
+			}
+		}
+
+		boolean bFace = bPhoto == null || Boolean.TRUE.equals(bPhoto);
+		if (bFace) {
+			Object largeFaceFlag = attributeList.get(ResidentAttribute.RA_LargeFace);
+			boolean generateLargeFace = largeFaceFlag != null
+					&& Boolean.parseBoolean(largeFaceFlag.toString());
+			Object obstructedFaceFlag = attributeList.get(ResidentAttribute.RA_ObstructedFace);
+			boolean generateObstructedFace = obstructedFaceFlag != null
+					&& Boolean.parseBoolean(obstructedFaceFlag.toString());
+
+			byte[][] faceData = PhotoProvider.getPhoto(contextKey, generateLargeFace, generateObstructedFace);
+			bioData.setEncodedPhoto(Base64.getEncoder().encodeToString(faceData[0]));
+			bioData.setRawFaceData(faceData[1]);
+			try {
+				bioData.setFaceHash(CommonUtil.getHexEncodedHash(faceData[1]));
+			} catch (Exception e1) {
+				logger.debug("Face hash skipped: {}", e1.getMessage());
+			}
+		}
+
+		resident.setBiometric(bioData);
+
+		oAttr = attributeList.get(ResidentAttribute.RA_Document);
+		boolean bDocRequired = oAttr == null || Boolean.parseBoolean(oAttr.toString());
+		if (bDocRequired) {
+			try {
+				Object lowQualityDocumentAttr = attributeList.get(ResidentAttribute.RA_LowQualityDocument);
+				boolean generateLowQualityDocuments = lowQualityDocumentAttr != null
+						&& Boolean.parseBoolean(lowQualityDocumentAttr.toString());
+				resident.setDocuments(DocumentProvider.generateDocuments(resident, contextKey,
+						generateLowQualityDocuments));
+				Object docCategoryAttr = attributeList.get(ResidentAttribute.RA_DocumentCategory);
+				if (docCategoryAttr != null && !docCategoryAttr.toString().trim().isEmpty()) {
+					String requiredDocCategory = docCategoryAttr.toString().trim();
+					resident.setDocuments(resident.getDocuments().stream()
+							.filter(doc -> doc != null && doc.getDocCategoryCode() != null
+									&& doc.getDocCategoryCode().equalsIgnoreCase(requiredDocCategory))
+							.collect(Collectors.toList()));
+				}
+			} catch (DocumentException | IOException | ParseException e) {
+				logger.error(e.getMessage());
+			}
+		}
+
+		if (resident.getDocuments() != null) {
+			for (MosipDocument doc : resident.getDocuments()) {
+				if (doc == null || doc.getDocs() == null || doc.getDocs().isEmpty()) {
+					continue;
+				}
+				String id = doc.getDocCategoryCode();
+				int index = CommonUtil.generateRandomNumbers(1, doc.getDocs().size() - 1, 0)[0];
+				resident.getDocIndexes().put(id, index);
+			}
+		}
+
+		resident.getAddtionalAttributes().put(ATTR_ASSEMBLED, "true");
+		resident.getAddtionalAttributes().remove(ATTR_DEFERRED);
+	}
+
+	public static void storeAssemblyHints(ResidentModel resident, Properties attributeList) {
+		if (resident == null || attributeList == null) {
+			return;
+		}
+		Hashtable<String, String> target = resident.getAddtionalAttributes();
+		attributeList.forEach((key, value) -> {
+			if (key instanceof ResidentAttribute ra && value != null) {
+				target.put(HINT_PREFIX + ra.name(), value.toString());
+			}
+		});
+	}
+
+	public static Properties hintsFromResident(ResidentModel resident) {
+		Properties props = new Properties();
+		if (resident == null || resident.getAddtionalAttributes() == null) {
+			return props;
+		}
+		resident.getAddtionalAttributes().forEach((key, value) -> {
+			if (key != null && key.startsWith(HINT_PREFIX) && value != null) {
+				String enumName = key.substring(HINT_PREFIX.length());
+				try {
+					ResidentAttribute ra = ResidentAttribute.valueOf(enumName);
+					props.put(ra, parseHintValue(ra, value));
+				} catch (IllegalArgumentException ignored) {
+					// skip unknown keys
+				}
+			}
+		});
+		return props;
+	}
+
+	private static Object parseHintValue(ResidentAttribute ra, String value) {
+		return switch (ra) {
+			case RA_Finger, RA_Photo, RA_Iris, RA_Document, RA_LargeFace, RA_ObstructedFace, RA_LowQualityDocument,
+					RA_SKipGaurdian ->
+				Boolean.parseBoolean(value);
+			case RA_Age -> ResidentAttribute.valueOf(value);
+			case RA_Gender -> io.mosip.testrig.dslrig.dataprovider.util.Gender.valueOf(value);
+			case RA_SCHEMA_VERSION -> Double.parseDouble(value);
+			default -> value;
+		};
+	}
+
+	public static void ensureBiometricShell(ResidentModel resident) {
+		if (resident != null && resident.getBiometric() == null) {
+			resident.setBiometric(new BiometricDataModel());
+		}
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaDemographicsBuilder.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaDemographicsBuilder.java
@@ -99,7 +99,7 @@ public final class PersonaDemographicsBuilder {
 		String thirdLang = (String) attributeList.get(ResidentAttribute.RA_THIRD_LANG);
 
 		Object oAttr = attributeList.get(ResidentAttribute.RA_SCHEMA_VERSION);
-		double schemaVersion = oAttr == null ? 0 : (double) oAttr;
+		double schemaVersion = parseSchemaVersion(oAttr);
 		VariableManager.setVariableValue(contextKey, "schemaVersion", schemaVersion);
 
 		String[] langsRequired = getConfiguredLanguages(contextKey);
@@ -320,12 +320,13 @@ public final class PersonaDemographicsBuilder {
 				res.setResidentStatus(lstResStatusPrimLang.get(indx));
 			}
 		}
-		if (res.getSecondaryLanguage() != null) {
+		if (res.getSecondaryLanguage() != null && lstResStatusPrimLang != null && !lstResStatusPrimLang.isEmpty()) {
 			List<MosipIndividualTypeModel> lstResStatusSecLang = ctx.resStatusList.get(res.getSecondaryLanguage());
 			if (lstResStatusSecLang != null) {
-				final int chosen = indx;
+				final int chosen = Math.min(indx, lstResStatusPrimLang.size() - 1);
+				String primaryCode = lstResStatusPrimLang.get(chosen).getCode();
 				for (MosipIndividualTypeModel itm : lstResStatusSecLang) {
-					if (itm.getCode().equals(lstResStatusPrimLang.get(chosen).getCode())) {
+					if (itm.getCode().equals(primaryCode)) {
 						res.setResidentStatus_seclang(itm);
 						break;
 					}
@@ -396,5 +397,20 @@ public final class PersonaDemographicsBuilder {
 		}
 		langArr = new String[minLanguages > 0 ? minLanguages : langs.size()];
 		return langs.toArray(langArr);
+	}
+
+	static double parseSchemaVersion(Object oAttr) {
+		if (oAttr == null) {
+			return 0;
+		}
+		if (oAttr instanceof Number number) {
+			return number.doubleValue();
+		}
+		try {
+			return Double.parseDouble(oAttr.toString().trim());
+		} catch (NumberFormatException e) {
+			logger.debug("Invalid schema version '{}', using 0", oAttr);
+			return 0;
+		}
 	}
 }

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaDemographicsBuilder.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/persona/PersonaDemographicsBuilder.java
@@ -1,0 +1,400 @@
+package io.mosip.testrig.dslrig.dataprovider.persona;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mosip.testrig.dslrig.dataprovider.BloodGroupProvider;
+import io.mosip.testrig.dslrig.dataprovider.ContactProvider;
+import io.mosip.testrig.dslrig.dataprovider.DateOfBirthProvider;
+import io.mosip.testrig.dslrig.dataprovider.LocationProvider;
+import io.mosip.testrig.dslrig.dataprovider.NameProvider;
+import io.mosip.testrig.dslrig.dataprovider.NrcIdProvider;
+import io.mosip.testrig.dslrig.dataprovider.ResidentDataProvider;
+import io.mosip.testrig.dslrig.dataprovider.models.ApplicationConfigIdSchema;
+import io.mosip.testrig.dslrig.dataprovider.models.Contact;
+import io.mosip.testrig.dslrig.dataprovider.models.DynamicFieldModel;
+import io.mosip.testrig.dslrig.dataprovider.models.DynamicFieldValueModel;
+import io.mosip.testrig.dslrig.dataprovider.models.MosipGenderModel;
+import io.mosip.testrig.dslrig.dataprovider.models.MosipIndividualTypeModel;
+import io.mosip.testrig.dslrig.dataprovider.models.MosipLanguage;
+import io.mosip.testrig.dslrig.dataprovider.models.MosipPreRegLoginConfig;
+import io.mosip.testrig.dslrig.dataprovider.models.Name;
+import io.mosip.testrig.dslrig.dataprovider.models.NrcId;
+import io.mosip.testrig.dslrig.dataprovider.models.ResidentModel;
+import io.mosip.testrig.dslrig.dataprovider.preparation.MosipMasterData;
+import io.mosip.testrig.dslrig.dataprovider.util.DataProviderConstants;
+import io.mosip.testrig.dslrig.dataprovider.util.Gender;
+import io.mosip.testrig.dslrig.dataprovider.util.ResidentAttribute;
+import io.mosip.testrig.dslrig.dataprovider.util.Translator;
+import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
+
+/**
+ * Demographics-only persona fields (names, locations, DOB, status) without biometric I/O.
+ */
+public final class PersonaDemographicsBuilder {
+
+	private static final Logger logger = LoggerFactory.getLogger(PersonaDemographicsBuilder.class);
+	private static final SecureRandom RAND = new SecureRandom();
+
+	private PersonaDemographicsBuilder() {
+	}
+
+	public static final class Context {
+		public final int count;
+		public final Gender gender;
+		public final String primaryLang;
+		public final String secLang;
+		public final String thirdLang;
+		public final Hashtable<String, List<DynamicFieldModel>> dynaFields;
+		public final List<MosipGenderModel> genderTypesPrimary;
+		public final List<MosipGenderModel> genderTypesSec;
+		public final List<MosipGenderModel> genderTypesThird;
+		public final List<Name> namesPrimary;
+		public final List<Name> namesSec;
+		public final List<Contact> contacts;
+		public final List<NrcId> nrcIds;
+		public final ApplicationConfigIdSchema locations;
+		public final ApplicationConfigIdSchema locationsSecLang;
+		public final Hashtable<String, List<DynamicFieldValueModel>> bloodGroups;
+		public final Hashtable<String, List<MosipIndividualTypeModel>> resStatusList;
+
+		Context(int count, Gender gender, String primaryLang, String secLang, String thirdLang,
+				Hashtable<String, List<DynamicFieldModel>> dynaFields, List<MosipGenderModel> genderTypesPrimary,
+				List<MosipGenderModel> genderTypesSec, List<MosipGenderModel> genderTypesThird, List<Name> namesPrimary,
+				List<Name> namesSec, List<Contact> contacts, List<NrcId> nrcIds, ApplicationConfigIdSchema locations,
+				ApplicationConfigIdSchema locationsSecLang,
+				Hashtable<String, List<DynamicFieldValueModel>> bloodGroups,
+				Hashtable<String, List<MosipIndividualTypeModel>> resStatusList) {
+			this.count = count;
+			this.gender = gender;
+			this.primaryLang = primaryLang;
+			this.secLang = secLang;
+			this.thirdLang = thirdLang;
+			this.dynaFields = dynaFields;
+			this.genderTypesPrimary = genderTypesPrimary;
+			this.genderTypesSec = genderTypesSec;
+			this.genderTypesThird = genderTypesThird;
+			this.namesPrimary = namesPrimary;
+			this.namesSec = namesSec;
+			this.contacts = contacts;
+			this.nrcIds = nrcIds;
+			this.locations = locations;
+			this.locationsSecLang = locationsSecLang;
+			this.bloodGroups = bloodGroups;
+			this.resStatusList = resStatusList;
+		}
+	}
+
+	public static Context prepare(Properties attributeList, String contextKey) throws Exception {
+		int count = 1;
+		Gender gender = (Gender) attributeList.get(ResidentAttribute.RA_Gender);
+		String primaryLang = (String) attributeList.get(ResidentAttribute.RA_PRIMARAY_LANG);
+		String secLang = (String) attributeList.get(ResidentAttribute.RA_SECONDARY_LANG);
+		String thirdLang = (String) attributeList.get(ResidentAttribute.RA_THIRD_LANG);
+
+		Object oAttr = attributeList.get(ResidentAttribute.RA_SCHEMA_VERSION);
+		double schemaVersion = oAttr == null ? 0 : (double) oAttr;
+		VariableManager.setVariableValue(contextKey, "schemaVersion", schemaVersion);
+
+		String[] langsRequired = getConfiguredLanguages(contextKey);
+		if (langsRequired != null) {
+			primaryLang = langsRequired[0];
+			if (langsRequired.length > 1) {
+				secLang = langsRequired[1];
+			}
+			if (langsRequired.length > 2) {
+				thirdLang = langsRequired[2];
+			}
+		}
+
+		String overridePrimary = (String) attributeList.get(ResidentAttribute.RA_PRIMARAY_LANG);
+		String overrideSec = (String) attributeList.get(ResidentAttribute.RA_SECONDARY_LANG);
+		if (overridePrimary != null && !overridePrimary.isEmpty()) {
+			primaryLang = overridePrimary;
+		}
+		if (overrideSec != null && !overrideSec.isEmpty()) {
+			secLang = overrideSec;
+		}
+
+		if (gender == null) {
+			gender = Gender.Any;
+		}
+
+		Hashtable<String, List<DynamicFieldModel>> dynaFields = MosipMasterData.getAllDynamicFields(contextKey);
+		List<MosipGenderModel> genderTypesPrimary = MosipMasterData.getGenderTypes(primaryLang, contextKey);
+		List<MosipGenderModel> genderTypesSec = secLang != null ? MosipMasterData.getGenderTypes(secLang, contextKey)
+				: null;
+		List<MosipGenderModel> genderTypesThird = thirdLang != null
+				? MosipMasterData.getGenderTypes(thirdLang, contextKey)
+				: null;
+
+		int maleCount = 0;
+		int femaleCount = 0;
+		switch (gender) {
+			case Any -> {
+				maleCount = count / 2;
+				femaleCount = count - maleCount;
+			}
+			case Male -> maleCount = count;
+			case Female -> femaleCount = count;
+			default -> {
+			}
+		}
+
+		List<Name> engMaleNames = null;
+		List<Name> engFemaleNames = null;
+		List<Name> engNames = null;
+		if (maleCount > 0) {
+			engMaleNames = NameProvider.generateNames(Gender.Male, DataProviderConstants.LANG_CODE_ENGLISH, maleCount,
+					null, contextKey);
+			engNames = engMaleNames;
+		}
+		if (femaleCount > 0) {
+			engFemaleNames = NameProvider.generateNames(Gender.Female, DataProviderConstants.LANG_CODE_ENGLISH,
+					femaleCount, null, contextKey);
+			if (engNames != null) {
+				engNames.addAll(engFemaleNames);
+			} else {
+				engNames = engFemaleNames;
+			}
+		}
+
+		List<Name> namesPrimary = null;
+		List<Name> namesSec = null;
+		if (primaryLang != null) {
+			if (!primaryLang.startsWith(DataProviderConstants.LANG_CODE_ENGLISH)) {
+				namesPrimary = NameProvider.generateNames(gender, primaryLang, count, engNames, contextKey);
+			} else {
+				namesPrimary = engNames;
+			}
+		}
+		if (secLang != null) {
+			if (!secLang.startsWith(DataProviderConstants.LANG_CODE_ENGLISH)) {
+				namesSec = NameProvider.generateNames(gender, secLang, count, engNames, contextKey);
+			} else {
+				namesSec = engNames;
+			}
+		}
+
+		List<Contact> contacts = ContactProvider.generate(engNames, count);
+		List<NrcId> nrcIds = NrcIdProvider.generate(count);
+		ApplicationConfigIdSchema locations = LocationProvider.generate(primaryLang, count, contextKey);
+		ApplicationConfigIdSchema locationsSecLang = secLang != null
+				? LocationProvider.generate(secLang, count, contextKey)
+				: null;
+
+		Hashtable<String, List<DynamicFieldValueModel>> bloodGroups = null;
+		if (dynaFields != null && !dynaFields.isEmpty()) {
+			bloodGroups = BloodGroupProvider.generate(count, dynaFields);
+		}
+
+		Hashtable<String, List<MosipIndividualTypeModel>> resStatusList = MosipMasterData.getIndividualTypes(contextKey);
+
+		return new Context(count, gender, primaryLang, secLang, thirdLang, dynaFields, genderTypesPrimary,
+				genderTypesSec, genderTypesThird, namesPrimary, namesSec, contacts, nrcIds, locations,
+				locationsSecLang, bloodGroups, resStatusList);
+	}
+
+	public static ResidentModel populate(int index, Context ctx, Properties attributeList, String contextKey)
+			throws Exception {
+		Gender resGender = ctx.namesPrimary.get(index).getGender();
+		ResidentModel res = new ResidentModel();
+		res.setPrimaryLanguage(ctx.primaryLang);
+		res.setSecondaryLanguage(ctx.secLang);
+		res.setThirdLanguage(ctx.thirdLang);
+		res.setDynaFields(ctx.dynaFields);
+		res.setName(ctx.namesPrimary.get(index));
+
+		res.getGenderTypes().put(ctx.primaryLang, ctx.genderTypesPrimary);
+		if (ctx.secLang != null) {
+			res.getGenderTypes().put(ctx.secLang, ctx.genderTypesSec);
+		}
+		if (ctx.thirdLang != null) {
+			res.getGenderTypes().put(ctx.thirdLang, ctx.genderTypesThird);
+		}
+
+		if (attributeList.containsKey(ResidentAttribute.RA_MissList)) {
+			res.setMissAttributes((List<String>) attributeList.get(ResidentAttribute.RA_MissList));
+		}
+		if (attributeList.containsKey(ResidentAttribute.RA_InvalidList)) {
+			res.setInvalidAttributes((List<String>) attributeList.get(ResidentAttribute.RA_InvalidList));
+		}
+
+		res.setGender(resGender);
+		if (ctx.namesSec != null) {
+			res.setName_seclang(ctx.namesSec.get(index));
+		}
+
+		if (ctx.bloodGroups != null && !ctx.bloodGroups.isEmpty()) {
+			res.setBloodgroup(ctx.bloodGroups.get(res.getPrimaryLanguage()).get(index));
+		}
+		res.setContact(ctx.contacts.get(index));
+		res.setNrcId(ctx.nrcIds.get(index));
+		res.setDob(DateOfBirthProvider.generate((ResidentAttribute) attributeList.get(ResidentAttribute.RA_Age),
+				contextKey));
+
+		ResidentAttribute age = (ResidentAttribute) attributeList.get(ResidentAttribute.RA_Age);
+		boolean skipGuardian = false;
+		if (age == ResidentAttribute.RA_Minor) {
+			res.setMinor(true);
+			if (attributeList.containsKey(ResidentAttribute.RA_SKipGaurdian)) {
+				skipGuardian = Boolean.parseBoolean(attributeList.get(ResidentAttribute.RA_SKipGaurdian).toString());
+			}
+			if (!skipGuardian) {
+				res.setGuardian(ResidentDataProvider.genGuardian(attributeList, contextKey));
+			}
+		} else if (age == ResidentAttribute.RA_Infant) {
+			res.setInfant(true);
+			if (attributeList.containsKey(ResidentAttribute.RA_SKipGaurdian)) {
+				skipGuardian = Boolean.parseBoolean(attributeList.get(ResidentAttribute.RA_SKipGaurdian).toString());
+			}
+			if (!skipGuardian) {
+				res.setGuardian(ResidentDataProvider.genGuardian(attributeList, contextKey));
+			}
+		}
+
+		res.setAppConfigIdSchema(ctx.locations);
+		res.setAppConfigIdSchema_secLang(ctx.locationsSecLang);
+		res.setLocation(ctx.locations.getTblLocations().get(index));
+
+		String[] addr = new String[DataProviderConstants.MAX_ADDRESS_LINES];
+		String addrFmt = "#%d, %d Street, %d block, lane #%d";
+		for (int ii = 0; ii < DataProviderConstants.MAX_ADDRESS_LINES; ii++) {
+			addr[ii] = String.format(addrFmt, (10 + RAND.nextInt(999)), (1 + RAND.nextInt(99)), (1 + RAND.nextInt(10)),
+					ii + 1);
+		}
+
+		String primLang = res.getPrimaryLanguage();
+		if (!primLang.toLowerCase().startsWith("en")) {
+			String[] addrP = new String[DataProviderConstants.MAX_ADDRESS_LINES];
+			for (int ii = 0; ii < DataProviderConstants.MAX_ADDRESS_LINES; ii++) {
+				addrP[ii] = Translator.translate(primLang, addr[ii], contextKey);
+			}
+			res.setAddress(addrP);
+		} else {
+			res.setAddress(addr);
+		}
+
+		if (res.getSecondaryLanguage() != null) {
+			res.setLocation_seclang(ctx.locationsSecLang.getTblLocations().get(index));
+			String[] addrSec = new String[DataProviderConstants.MAX_ADDRESS_LINES];
+			for (int ii = 0; ii < DataProviderConstants.MAX_ADDRESS_LINES; ii++) {
+				addrSec[ii] = Translator.translate(res.getSecondaryLanguage(), addr[ii], contextKey);
+			}
+			res.setAddress_seclang(addrSec);
+		}
+
+		applyResidentStatus(res, ctx, index);
+		applySkipFlagsFromAttributes(res, attributeList);
+		return res;
+	}
+
+	private static void applySkipFlagsFromAttributes(ResidentModel res, Properties attributeList) {
+		Object finger = attributeList.get(ResidentAttribute.RA_Finger);
+		res.setSkipFinger(finger == null ? false : !(Boolean) finger);
+		Object photo = attributeList.get(ResidentAttribute.RA_Photo);
+		res.setSkipFace(photo == null ? false : !(Boolean) photo);
+		Object iris = attributeList.get(ResidentAttribute.RA_Iris);
+		res.setSkipIris(iris == null ? false : !(Boolean) iris);
+	}
+
+	private static void applyResidentStatus(ResidentModel res, Context ctx, int index) {
+		List<MosipIndividualTypeModel> lstResStatusPrimLang = ctx.resStatusList.get(res.getPrimaryLanguage());
+		int indx = 0;
+		if (lstResStatusPrimLang != null) {
+			for (MosipIndividualTypeModel itm : lstResStatusPrimLang) {
+				if (itm.getCode().equals("NFR")) {
+					res.setResidentStatus(itm);
+					break;
+				}
+				indx++;
+			}
+			if (res.getResidentStatus() == null) {
+				indx = RAND.nextInt(lstResStatusPrimLang.size());
+				res.setResidentStatus(lstResStatusPrimLang.get(indx));
+			}
+		}
+		if (res.getSecondaryLanguage() != null) {
+			List<MosipIndividualTypeModel> lstResStatusSecLang = ctx.resStatusList.get(res.getSecondaryLanguage());
+			if (lstResStatusSecLang != null) {
+				final int chosen = indx;
+				for (MosipIndividualTypeModel itm : lstResStatusSecLang) {
+					if (itm.getCode().equals(lstResStatusPrimLang.get(chosen).getCode())) {
+						res.setResidentStatus_seclang(itm);
+						break;
+					}
+				}
+			}
+			if (res.getResidentStatus_seclang() == null) {
+				res.setResidentStatus_seclang(res.getResidentStatus());
+			}
+		}
+	}
+
+	private static String[] getConfiguredLanguages(String contextKey) {
+		String[] langArr = null;
+		List<String> langs = new ArrayList<>();
+		List<MosipLanguage> allLang = null;
+		try {
+			allLang = MosipMasterData.getConfiguredLanguages(contextKey);
+		} catch (Exception e) {
+			logger.error(e.getMessage());
+		}
+
+		MosipPreRegLoginConfig preregconfig = MosipMasterData.getPreregLoginConfig(contextKey);
+		if (preregconfig == null) {
+			try {
+				langArr = new String[allLang.size()];
+				int i = 0;
+				for (MosipLanguage l : allLang) {
+					langArr[i] = l.getIso2();
+					i++;
+				}
+			} catch (Exception e) {
+				logger.error(e.getMessage());
+			}
+			return langArr;
+		}
+
+		String primaryLang = preregconfig.getMosip_primary_language();
+		if (primaryLang != null) {
+			langs.add(primaryLang);
+		}
+
+		String mandatoryLanguagesList = preregconfig.getMandatory_languages();
+		String[] mandatLanguages = null;
+		if (mandatoryLanguagesList != null && !mandatoryLanguagesList.equals("")) {
+			mandatLanguages = mandatoryLanguagesList.split(",");
+		}
+		int minLanguages = Integer.parseInt(preregconfig.getMin_languages_count());
+		String optLangList = preregconfig.getOptional_languages();
+		String[] optLangs = null;
+		if (optLangList != null && !optLangList.equals("")) {
+			optLangs = optLangList.split(",");
+		}
+		if (mandatLanguages != null && mandatLanguages.length > 0) {
+			for (int i = 0; i < mandatLanguages.length; i++) {
+				langs.add(mandatLanguages[i]);
+			}
+		}
+		if (optLangs != null && optLangs.length > 0) {
+			for (int i = 0; i < optLangs.length; i++) {
+				langs.add(optLangs[i]);
+			}
+		}
+		if (minLanguages > 0 && langs.size() < minLanguages && allLang != null) {
+			int n2add = minLanguages - langs.size();
+			for (int i = 0; i < allLang.size() && i < n2add; i++) {
+				langs.add(allLang.get(i).getIso2());
+			}
+		}
+		langArr = new String[minLanguages > 0 ? minLanguages : langs.size()];
+		return langs.toArray(langArr);
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/MasterdataCache.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/MasterdataCache.java
@@ -1,0 +1,154 @@
+package io.mosip.testrig.dslrig.dataprovider.preparation;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
+
+/**
+ * Unified run-scoped cache for MOSIP masterdata (GET JSON, parsed entities, derived values).
+ * All entries live in the {@code {urlBase}run_context} namespace with normalized {@code md:*} keys.
+ * Legacy unprefixed keys are still read for backward compatibility within the same JVM.
+ */
+public final class MasterdataCache {
+
+	public static final String CACHE_VERSION = "2";
+
+	public static final String PREFIX_GET = "md:get:";
+	public static final String PREFIX_ENTITY = "md:entity:";
+
+	/**
+	 * Logical operations performed by {@link RunCacheService#warm(String)} (idempotent per run).
+	 */
+	public static final List<String> WARM_OPERATIONS = List.of(
+			"auth:system",
+			"auth:admin",
+			"auth:resident",
+			"auth:regproc",
+			"masterdata:languages",
+			"masterdata:genderTypes",
+			"masterdata:locationHierarchy",
+			"masterdata:dynamicFields",
+			"masterdata:idSchemaLatest",
+			"masterdata:individualTypes",
+			"masterdata:documentCategories",
+			"masterdata:validDocuments",
+			"masterdata:locationImmediateChildren",
+			"masterdata:preregLocationHierarchy",
+			"masterdata:preregLoginConfig");
+
+	private MasterdataCache() {
+	}
+
+	public static boolean isEnabled(String contextKey) {
+		try {
+			Object flag = VariableManager.getVariableValue(contextKey, "disableRunMasterdataCache");
+			if (flag != null && Boolean.parseBoolean(flag.toString())) {
+				return false;
+			}
+		} catch (Exception ignored) {
+			// default enabled
+		}
+		return true;
+	}
+
+	public static boolean isCacheableGetUrl(String url) {
+		if (url == null || url.isBlank()) {
+			return false;
+		}
+		String lower = url.toLowerCase(Locale.ROOT);
+		if (!lower.contains("/masterdata/")) {
+			return false;
+		}
+		if (lower.contains("/actuator/")) {
+			return false;
+		}
+		return !isBiometricOrMockAbisUrl(lower);
+	}
+
+	public static boolean isBiometricOrMockAbisUrl(String urlLowerCase) {
+		if (urlLowerCase == null || urlLowerCase.isBlank()) {
+			return false;
+		}
+		return urlLowerCase.contains("/biometric")
+				|| urlLowerCase.contains("mock-abis")
+				|| (urlLowerCase.contains("/idrepository/") && urlLowerCase.contains("idvid"));
+	}
+
+	public static String buildGetKey(String url, JSONObject requestParams, JSONObject pathParam) {
+		StringBuilder sb = new StringBuilder(PREFIX_GET);
+		sb.append(url);
+		if (pathParam != null && !pathParam.isEmpty()) {
+			sb.append("|path:").append(pathParam);
+		}
+		if (requestParams != null && !requestParams.isEmpty()) {
+			sb.append("|query:").append(requestParams);
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Normalizes a cache key for storage. Auth keys and existing {@code md:*} keys are unchanged.
+	 */
+	public static String normalizeKey(String key) {
+		if (key == null || key.isBlank()) {
+			return key;
+		}
+		if (key.startsWith("md:") || key.startsWith("auth:")) {
+			return key;
+		}
+		return PREFIX_ENTITY + key;
+	}
+
+	public static Object get(String contextKey, String key) {
+		return getByNamespace(MosipDataSetup.getRunContextNamespace(contextKey), key);
+	}
+
+	public static void put(String contextKey, String key, Object value) {
+		putByNamespace(MosipDataSetup.getRunContextNamespace(contextKey), key, value);
+	}
+
+	public static Object getByNamespace(String runContextNamespace, String key) {
+		if (runContextNamespace == null || key == null) {
+			return null;
+		}
+		String normalized = normalizeKey(key);
+		Object cached = MosipDataSetup.readCacheRaw(normalized, runContextNamespace);
+		if (cached == null && !normalized.equals(key)) {
+			cached = MosipDataSetup.readCacheRaw(key, runContextNamespace);
+		}
+		return cached;
+	}
+
+	public static void putByNamespace(String runContextNamespace, String key, Object value) {
+		if (runContextNamespace == null || key == null || value == null) {
+			return;
+		}
+		MosipDataSetup.writeCacheRaw(normalizeKey(key), value, runContextNamespace);
+	}
+
+	public static JSONObject getCachedGetJson(String contextKey, String getKey) {
+		Object cached = get(contextKey, getKey);
+		return cached instanceof JSONObject ? (JSONObject) cached : null;
+	}
+
+	public static void putCachedGetJson(String contextKey, String getKey, JSONObject value) {
+		put(contextKey, getKey, value);
+	}
+
+	public static JSONArray getCachedGetArray(String contextKey, String getKey) {
+		Object cached = get(contextKey, getKey);
+		return cached instanceof JSONArray ? (JSONArray) cached : null;
+	}
+
+	public static void putCachedGetArray(String contextKey, String getKey, JSONArray value) {
+		put(contextKey, getKey, value);
+	}
+
+	public static void clearContext(String contextKey) {
+		MosipDataSetup.clearRunCache(contextKey);
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/MasterdataCache.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/MasterdataCache.java
@@ -132,20 +132,38 @@ public final class MasterdataCache {
 
 	public static JSONObject getCachedGetJson(String contextKey, String getKey) {
 		Object cached = get(contextKey, getKey);
-		return cached instanceof JSONObject ? (JSONObject) cached : null;
+		if (cached instanceof JSONObject json) {
+			return copyJsonObject(json);
+		}
+		return null;
 	}
 
 	public static void putCachedGetJson(String contextKey, String getKey, JSONObject value) {
-		put(contextKey, getKey, value);
+		if (value != null) {
+			put(contextKey, getKey, copyJsonObject(value));
+		}
 	}
 
 	public static JSONArray getCachedGetArray(String contextKey, String getKey) {
 		Object cached = get(contextKey, getKey);
-		return cached instanceof JSONArray ? (JSONArray) cached : null;
+		if (cached instanceof JSONArray array) {
+			return copyJsonArray(array);
+		}
+		return null;
 	}
 
 	public static void putCachedGetArray(String contextKey, String getKey, JSONArray value) {
-		put(contextKey, getKey, value);
+		if (value != null) {
+			put(contextKey, getKey, copyJsonArray(value));
+		}
+	}
+
+	private static JSONObject copyJsonObject(JSONObject source) {
+		return new JSONObject(source.toString());
+	}
+
+	private static JSONArray copyJsonArray(JSONArray source) {
+		return new JSONArray(source.toString());
 	}
 
 	public static void clearContext(String contextKey) {

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/MosipDataSetup.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/MosipDataSetup.java
@@ -64,20 +64,37 @@ public class MosipDataSetup {
 		return props;
 	}
 
-	public static Object getCache(String key, String contextKey) {
-
+	/**
+	 * @param runContextNamespace {@link #getRunContextNamespace(String)} value, not DSL contextKey
+	 */
+	public static Object getCache(String key, String runContextNamespace) {
 		try {
-			logger.debug("Getting cache for key: {} with context: {}", key, contextKey);
-			return fromCacheValue(VariableManager.getVariableValue(contextKey, key));
+			logger.debug("Getting cache for key: {} with namespace: {}", key, runContextNamespace);
+			return MasterdataCache.getByNamespace(runContextNamespace, key);
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 		}
 		return null;
 	}
 
-	public static void setCache(String key, Object value, String contextKey) {
+	/**
+	 * @param runContextNamespace {@link #getRunContextNamespace(String)} value, not DSL contextKey
+	 */
+	public static void setCache(String key, Object value, String runContextNamespace) {
+		MasterdataCache.putByNamespace(runContextNamespace, key, value);
+	}
 
-		VariableManager.setVariableValue(contextKey, key, toCacheValue(value));
+	static Object readCacheRaw(String key, String runContextNamespace) {
+		try {
+			return fromCacheValue(VariableManager.getVariableValue(runContextNamespace, key));
+		} catch (Exception e) {
+			logger.debug("Cache read failed for key {}: {}", key, e.getMessage());
+		}
+		return null;
+	}
+
+	static void writeCacheRaw(String key, Object value, String runContextNamespace) {
+		VariableManager.setVariableValue(runContextNamespace, key, toCacheValue(value));
 	}
 
 	public static Object toCacheValue(Object value) {

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/RunCacheService.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/RunCacheService.java
@@ -15,6 +15,10 @@ import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
 /**
  * Pre-loads MOSIP masterdata and auth tokens into the per-run cache ({@code urlBase + run_context})
  * so packet generation does not repeat the same GET/POST calls for every scenario.
+ * <p>
+ * Suite flow: {@code POST /runCache/warm/{contextKey}} once per worker → scenarios →
+ * {@code POST /runCache/clear/{contextKey}}. Cached via {@link MasterdataCache} (keys {@code md:get:*},
+ * {@code md:entity:*}). See {@link MasterdataCache#WARM_OPERATIONS}.
  */
 public final class RunCacheService {
 
@@ -26,10 +30,16 @@ public final class RunCacheService {
 	public static Map<String, Object> warm(String contextKey) {
 		Map<String, Object> summary = new LinkedHashMap<>();
 		summary.put("contextKey", contextKey);
+		summary.put("masterdataCacheVersion", MasterdataCache.CACHE_VERSION);
 
 		try {
 			Object urlBase = VariableManager.getVariableValue(contextKey, "urlBase");
-			summary.put("urlBase", urlBase != null ? urlBase.toString() : "unknown");
+			if (urlBase == null || urlBase.toString().isBlank()) {
+				summary.put("urlBase", "missing");
+				logger.warn("Run cache warm: urlBase not set for context {}", contextKey);
+				return summary;
+			}
+			summary.put("urlBase", urlBase.toString().trim());
 		} catch (Exception e) {
 			summary.put("urlBase", "missing");
 			logger.warn("Run cache warm: urlBase not set for context {}", contextKey);

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/RunScopedMasterdataCache.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/preparation/RunScopedMasterdataCache.java
@@ -1,91 +1,46 @@
 package io.mosip.testrig.dslrig.dataprovider.preparation;
 
-import java.util.Locale;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
-
 /**
- * Run-scoped cache for idempotent MOSIP masterdata GET responses.
- * Keyed by full URL + query/path params in the shared {@code {urlBase}run_context} namespace.
+ * @deprecated Use {@link MasterdataCache} directly. Retained as a thin delegate for {@code RestClient}.
  */
+@Deprecated
 public final class RunScopedMasterdataCache {
-
-	private static final String CACHE_PREFIX = "md:get:";
 
 	private RunScopedMasterdataCache() {
 	}
 
 	public static boolean isEnabled(String contextKey) {
-		try {
-			Object flag = VariableManager.getVariableValue(contextKey, "disableRunMasterdataCache");
-			if (flag != null && Boolean.parseBoolean(flag.toString())) {
-				return false;
-			}
-		} catch (Exception ignored) {
-			// default enabled
-		}
-		return true;
+		return MasterdataCache.isEnabled(contextKey);
 	}
 
 	public static boolean isCacheableGetUrl(String url) {
-		if (url == null || url.isBlank()) {
-			return false;
-		}
-		String lower = url.toLowerCase(Locale.ROOT);
-		if (!lower.contains("/masterdata/")) {
-			return false;
-		}
-		if (lower.contains("/actuator/")) {
-			return false;
-		}
-		// Biometric masterdata and mock-abis are not run-cached: each scenario needs its own capture/expectations.
-		return !isBiometricOrMockAbisUrl(lower);
+		return MasterdataCache.isCacheableGetUrl(url);
 	}
 
-	/** URLs that must not use run-scoped cache (unique biometrics per scenario). */
 	public static boolean isBiometricOrMockAbisUrl(String urlLowerCase) {
-		if (urlLowerCase == null || urlLowerCase.isBlank()) {
-			return false;
-		}
-		return urlLowerCase.contains("/biometric")
-				|| urlLowerCase.contains("mock-abis")
-				|| (urlLowerCase.contains("/idrepository/") && urlLowerCase.contains("idvid"));
+		return MasterdataCache.isBiometricOrMockAbisUrl(urlLowerCase);
 	}
 
 	public static String buildCacheKey(String url, JSONObject requestParams, JSONObject pathParam) {
-		StringBuilder sb = new StringBuilder(CACHE_PREFIX);
-		sb.append(url);
-		if (pathParam != null && !pathParam.isEmpty()) {
-			sb.append("|path:").append(pathParam.toString());
-		}
-		if (requestParams != null && !requestParams.isEmpty()) {
-			sb.append("|query:").append(requestParams.toString());
-		}
-		return sb.toString();
+		return MasterdataCache.buildGetKey(url, requestParams, pathParam);
 	}
 
 	public static JSONObject getCachedJson(String contextKey, String cacheKey) {
-		Object cached = MosipDataSetup.getCache(cacheKey, MosipDataSetup.getRunContextNamespace(contextKey));
-		return cached instanceof JSONObject ? (JSONObject) cached : null;
+		return MasterdataCache.getCachedGetJson(contextKey, cacheKey);
 	}
 
 	public static void putCachedJson(String contextKey, String cacheKey, JSONObject value) {
-		if (value != null) {
-			MosipDataSetup.setCache(cacheKey, value, MosipDataSetup.getRunContextNamespace(contextKey));
-		}
+		MasterdataCache.putCachedGetJson(contextKey, cacheKey, value);
 	}
 
 	public static JSONArray getCachedArray(String contextKey, String cacheKey) {
-		Object cached = MosipDataSetup.getCache(cacheKey, MosipDataSetup.getRunContextNamespace(contextKey));
-		return cached instanceof JSONArray ? (JSONArray) cached : null;
+		return MasterdataCache.getCachedGetArray(contextKey, cacheKey);
 	}
 
 	public static void putCachedArray(String contextKey, String cacheKey, JSONArray value) {
-		if (value != null) {
-			MosipDataSetup.setCache(cacheKey, value, MosipDataSetup.getRunContextNamespace(contextKey));
-		}
+		MasterdataCache.putCachedGetArray(contextKey, cacheKey, value);
 	}
 }

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/test/CreatePersona.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/test/CreatePersona.java
@@ -16,7 +16,6 @@ import org.mvel2.MVEL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.cucumber.core.gherkin.messages.internal.gherkin.internal.com.eclipsesource.json.Json;
 import io.mosip.testrig.dslrig.dataprovider.PacketTemplateProvider;
 import io.mosip.testrig.dslrig.dataprovider.models.DynamicFieldModel;
 import io.mosip.testrig.dslrig.dataprovider.models.MosipGenderModel;
@@ -43,7 +42,7 @@ public class CreatePersona {
 
 		obj.put("language", primLang);
 		if(primVal != null && primVal.equals(""))
-			obj.put("value", Json.NULL);
+			obj.put("value", JSONObject.NULL);
 		else
 			obj.put("value", primVal);
 		if(bSimpleType){
@@ -53,7 +52,7 @@ public class CreatePersona {
 				obj = new JSONObject();
 				obj.put("language", secLang);
 				if(secVal != null && secVal.equals(""))
-					obj.put("value", Json.NULL);
+					obj.put("value", JSONObject.NULL);
 				else
 					obj.put("value", secVal);
 				array.put(1, obj);

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/AuthTokenStore.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/AuthTokenStore.java
@@ -1,0 +1,67 @@
+package io.mosip.testrig.dslrig.dataprovider.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory auth tokens keyed by DSL {@code contextKey}, then role ({@code system}, {@code admin}, …).
+ * Isolates parallel workers that share the same {@code urlBase} but use different credentials.
+ */
+public final class AuthTokenStore {
+
+	public static final String ROLE_SYSTEM = "system";
+	public static final String ROLE_ADMIN = "admin";
+	public static final String ROLE_RESIDENT = "resident";
+	public static final String ROLE_REGPROC = "regproc";
+	public static final String ROLE_CRVS = "crvs";
+	public static final String ROLE_PREREG = "prereg";
+
+	private static final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> BY_CONTEXT = new ConcurrentHashMap<>();
+
+	private AuthTokenStore() {
+	}
+
+	public static String get(String contextKey, String role) {
+		if (contextKey == null || contextKey.isBlank() || role == null) {
+			return null;
+		}
+		Map<String, String> roles = BY_CONTEXT.get(normalize(contextKey));
+		return roles == null ? null : roles.get(role);
+	}
+
+	public static void put(String contextKey, String role, String token) {
+		if (contextKey == null || contextKey.isBlank() || role == null) {
+			return;
+		}
+		BY_CONTEXT.computeIfAbsent(normalize(contextKey), k -> new ConcurrentHashMap<>()).put(role, token);
+	}
+
+	public static void remove(String contextKey, String role) {
+		if (contextKey == null || contextKey.isBlank() || role == null) {
+			return;
+		}
+		Map<String, String> roles = BY_CONTEXT.get(normalize(contextKey));
+		if (roles != null) {
+			roles.remove(role);
+		}
+	}
+
+	public static void clearContext(String contextKey) {
+		if (contextKey == null || contextKey.isBlank()) {
+			return;
+		}
+		BY_CONTEXT.remove(normalize(contextKey));
+	}
+
+	/**
+	 * Clears tokens for every context. Avoid during parallel DSL runs; prefer
+	 * {@link #clearContext(String)} via {@code clearRunScopedCache}.
+	 */
+	public static void clearAll() {
+		BY_CONTEXT.clear();
+	}
+
+	private static String normalize(String contextKey) {
+		return contextKey.trim();
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/AuthTokenStore.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/AuthTokenStore.java
@@ -30,7 +30,7 @@ public final class AuthTokenStore {
 	}
 
 	public static void put(String contextKey, String role, String token) {
-		if (contextKey == null || contextKey.isBlank() || role == null) {
+		if (contextKey == null || contextKey.isBlank() || role == null || token == null || token.isBlank()) {
 			return;
 		}
 		BY_CONTEXT.computeIfAbsent(normalize(contextKey), k -> new ConcurrentHashMap<>()).put(role, token);

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
@@ -69,6 +69,20 @@ public class RestClient {
 	private static final String AUTHURL = " Auth URL";
 	private static final String POST2SLACK = "post2slack";
 
+	/** Extracts cookie value from {@code Set-Cookie} (stops at first {@code ;}). */
+	static String tokenFromSetCookie(String setCookieHeader) {
+		if (setCookieHeader == null || setCookieHeader.isBlank()) {
+			return null;
+		}
+		int eq = setCookieHeader.indexOf('=');
+		if (eq < 0 || eq + 1 >= setCookieHeader.length()) {
+			return null;
+		}
+		String value = setCookieHeader.substring(eq + 1);
+		int semi = value.indexOf(';');
+		return (semi >= 0 ? value.substring(0, semi) : value).trim();
+	}
+
 	static {
 
 
@@ -675,9 +689,9 @@ public class RestClient {
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 
-			String[] parts = cookie.split("=");
-			if (parts.length > 1) {
-				token = parts[1].split(";")[0];
+			String refreshed = tokenFromSetCookie(cookie);
+			if (refreshed != null) {
+				token = refreshed;
 				AuthTokenStore.put(contextKey, role, token);
 			}
 
@@ -726,12 +740,10 @@ public class RestClient {
 				logInfo(contextKey, h.getName() + "=" + h.getValue());
 			}
 			String cookie = response.getHeader(SET_COOKIE);
-			if (cookie != null && cookie.contains("=")) {
-				String[] parts = cookie.split("=", 2);
-				if (parts.length > 1) {
-					token = parts[1].split(";")[0];
-					AuthTokenStore.put(contextKey, role, token);
-				}
+			String refreshed = tokenFromSetCookie(cookie);
+			if (refreshed != null) {
+				token = refreshed;
+				AuthTokenStore.put(contextKey, role, token);
 			}
 			logInfo(contextKey, token);
 			checkErrorResponse(response.getBody().asString(), url);
@@ -774,7 +786,7 @@ public class RestClient {
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
-			token = cookie.split("=")[1];
+			token = tokenFromSetCookie(cookie);
 			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
@@ -805,7 +817,7 @@ public class RestClient {
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
-			token = cookie.split("=")[1];
+			token = tokenFromSetCookie(cookie);
 			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
@@ -834,7 +846,7 @@ public class RestClient {
 			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
-			token = cookie.split("=")[1];
+			token = tokenFromSetCookie(cookie);
 			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
@@ -862,7 +874,7 @@ public class RestClient {
 			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
-			token = cookie.split("=")[1];
+			token = tokenFromSetCookie(cookie);
 			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
@@ -893,7 +905,7 @@ public class RestClient {
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
-			token = cookie.split("=")[1];
+			token = tokenFromSetCookie(cookie);
 			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
@@ -969,7 +981,7 @@ public class RestClient {
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 
-			String token = cookie.split("=")[1];
+			String token = tokenFromSetCookie(cookie);
 
 			AuthTokenStore.put(contextKey, role, token);
 		}
@@ -1028,7 +1040,7 @@ public class RestClient {
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 
-			String token = cookie.split("=")[1];
+			String token = tokenFromSetCookie(cookie);
 			AuthTokenStore.put(contextKey, role, token);
 
 		}
@@ -1109,7 +1121,7 @@ public class RestClient {
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 
-			String token = cookie.split("=")[1];
+			String token = tokenFromSetCookie(cookie);
 			AuthTokenStore.put(contextKey, role, token);
 
 		}
@@ -1156,7 +1168,7 @@ public class RestClient {
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 
-			String token = cookie.split("=")[1];
+			String token = tokenFromSetCookie(cookie);
 
 			AuthTokenStore.put(contextKey, role, token);
 		}
@@ -1203,7 +1215,7 @@ public class RestClient {
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 
-			String token = cookie.split("=")[1];
+			String token = tokenFromSetCookie(cookie);
 
 			AuthTokenStore.put(contextKey, role, token);
 		}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClient.java
@@ -1,7 +1,6 @@
 package io.mosip.testrig.dslrig.dataprovider.util;
 
 import static io.restassured.RestAssured.given;
-import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -12,7 +11,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -29,13 +27,9 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.http.HttpStatus;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.exceptions.JWTDecodeException;
-import com.auth0.jwt.interfaces.DecodedJWT;
-
 import io.mosip.testrig.dslrig.dataprovider.mds.HttpRCapture;
 import io.mosip.testrig.dslrig.dataprovider.preparation.MosipDataSetup;
-import io.mosip.testrig.dslrig.dataprovider.preparation.RunScopedMasterdataCache;
+import io.mosip.testrig.dslrig.dataprovider.preparation.MasterdataCache;
 import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiLogging;
 import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiManualRecorder;
 import io.mosip.testrig.dslrig.dataprovider.util.internalapi.InternalApiRestAssuredFilter;
@@ -52,8 +46,6 @@ public class RestClient {
 
 	static String dataKey = "response";
 	static String errorKey = "errors";
-	static Map<String, String> tokens = new HashMap<String, String>();
-	static String refreshToken;
 
 
 	private static final String URLBASE = "urlBase";
@@ -82,7 +74,7 @@ public class RestClient {
 
 	}
 
-	private static RequestSpecification givenFiltered(String contextKey) {
+	static RequestSpecification requestSpec(String contextKey) {
 		RequestSpecification spec = given();
 		if (InternalApiLogging.isEnabled(contextKey)) {
 			spec = spec.filter(new InternalApiRestAssuredFilter(contextKey));
@@ -95,82 +87,25 @@ public class RestClient {
 	int http_status;
 	Properties headers;
 
-	private static boolean shouldForceAuthRefresh(String contextKey) {
-		try {
-			Object obj = VariableManager.getVariableValue(contextKey, "urlSwitched");
-			if (obj != null) {
-				return Boolean.parseBoolean(obj.toString());
-			}
-		} catch (Exception ignored) {
-			// allow run-cache reuse
-		}
-		return false;
-	}
-
 	public static Boolean isValidToken(String role, String contextKey) {
-
-		if (shouldForceAuthRefresh(contextKey)) {
-			return false;
-		}
-
-		Object urlBase = VariableManager.getVariableValue(contextKey, URLBASE);
-
-		if (urlBase != null) {
-			String tokenKey = urlBase.toString().trim() + role;
-			String token = tokens.get(tokenKey);
-			if (token == null || token.isEmpty()) {
-				restoreAuthTokenFromRunCache(role, contextKey);
-				token = tokens.get(tokenKey);
-			}
-			if (token != null && !token.isEmpty()) {
-				return isValidTokenOffline(token, contextKey);
-			}
-		} else {
-			return false;
-		}
-		return false;
+		return RestClientAuth.isValidToken(role, contextKey);
 	}
 
 	public static boolean isValidTokenOffline(String cookie, String contextKey) {
-		boolean bReturn = false;
-		if (cookie == null)
-			return bReturn;
-		try {
-			DecodedJWT decodedJWT = JWT.decode(cookie);
-			long expirationTime = decodedJWT.getExpiresAt().getTime();
-			if (expirationTime < System.currentTimeMillis()) {
-				logInfo(contextKey, "The token is expired");
-			} else {
-				bReturn = true;
-				logInfo(contextKey, "The token is not expired");
-			}
-		} catch (JWTDecodeException e) {
-			logger.error("The token is invalid");
-		}
-		return bReturn;
+		return RestClientAuth.isValidTokenOffline(cookie, contextKey);
 	}
 
+	/**
+	 * @deprecated Prefer {@link #clearRunScopedCache(String)} for a single DSL context.
+	 */
+	@Deprecated
 	public static void clearToken() {
-		tokens.clear();
-		refreshToken = null;
+		AuthTokenStore.clearAll();
 	}
 
 	public static void clearRunScopedCache(String contextKey) {
 		MosipDataSetup.clearRunCache(contextKey);
-		clearTokensForUrlBase(contextKey);
-	}
-
-	private static void clearTokensForUrlBase(String contextKey) {
-		try {
-			Object urlBase = VariableManager.getVariableValue(contextKey, URLBASE);
-			if (urlBase == null) {
-				return;
-			}
-			String prefix = urlBase.toString().trim();
-			tokens.keySet().removeIf(key -> key.startsWith(prefix));
-		} catch (Exception e) {
-			logger.debug("Could not clear tokens for context {}", contextKey);
-		}
+		AuthTokenStore.clearContext(contextKey);
 	}
 
 	public int status() {
@@ -222,17 +157,16 @@ public class RestClient {
 		try {
 			while (!bDone) {
 
-				String token = tokens
-						.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+				String token = AuthTokenStore.get(contextKey, role);
 				Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 				Map<String, Object> mapParam = requestParams == null ? null : requestParams.toMap();
 				Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 				if (isDebugEnabled(contextKey)) {
-					response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+					response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 							.get(url, mapPathParam).then().log().all().extract().response();
 				} else {
-					response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+					response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 							mapPathParam);
 				}
 				if (response.getStatusCode() == 401) {
@@ -296,17 +230,16 @@ public class RestClient {
 		try {
 			while (!bDone) {
 
-				String token = tokens
-						.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+				String token = AuthTokenStore.get(contextKey, role);
 				Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 				Map<String, Object> mapParam = requestParams == null ? null : requestParams.toMap();
 				Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 				if (isDebugEnabled(contextKey)) {
-					response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+					response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 							.get(url, mapPathParam).then().log().all().extract().response();
 				} else {
-					response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+					response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 							mapPathParam);
 				}
 
@@ -343,9 +276,9 @@ public class RestClient {
 			throws Exception {
 
 		String runCacheKey = null;
-		if (RunScopedMasterdataCache.isEnabled(contextKey) && RunScopedMasterdataCache.isCacheableGetUrl(url)) {
-			runCacheKey = RunScopedMasterdataCache.buildCacheKey(url, requestParams, pathParam);
-			JSONObject cached = RunScopedMasterdataCache.getCachedJson(contextKey, runCacheKey);
+		if (MasterdataCache.isEnabled(contextKey) && MasterdataCache.isCacheableGetUrl(url)) {
+			runCacheKey = MasterdataCache.buildGetKey(url, requestParams, pathParam);
+			JSONObject cached = MasterdataCache.getCachedGetJson(contextKey, runCacheKey);
 			if (cached != null) {
 				return cached;
 			}
@@ -363,17 +296,16 @@ public class RestClient {
 		try {
 			while (!bDone) {
 
-				String token = tokens
-						.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+				String token = AuthTokenStore.get(contextKey, role);
 				Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 				Map<String, Object> mapParam = requestParams == null ? null : requestParams.toMap();
 				Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 				if (isDebugEnabled(contextKey)) {
-					response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+					response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 							.get(url, mapPathParam).then().log().all().extract().response();
 				} else {
-					response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+					response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 							mapPathParam);
 				}
 
@@ -420,7 +352,7 @@ public class RestClient {
 		}
 
 		if (runCacheKey != null) {
-			RunScopedMasterdataCache.putCachedJson(contextKey, runCacheKey, result);
+			MasterdataCache.putCachedGetJson(contextKey, runCacheKey, result);
 		}
 		return result;
 	}
@@ -429,7 +361,7 @@ public class RestClient {
 
 		Response response = null;
 		try {
-			response = givenFiltered(null)
+			response = requestSpec(null)
 					.relaxedHTTPSValidation()
 					.log().all()
 					.when()
@@ -459,10 +391,10 @@ public class RestClient {
 			Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 			if (isDebugEnabled(contextKey)) {
-				response = givenFiltered(contextKey).log().all().contentType(ContentType.JSON).queryParams(mapParam)
+				response = requestSpec(contextKey).log().all().contentType(ContentType.JSON).queryParams(mapParam)
 						.get(url, mapPathParam).then().log().all().extract().response();
 			} else {
-				response = givenFiltered(contextKey).contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
+				response = requestSpec(contextKey).contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
 			}
 
 			if (isDebugEnabled(contextKey) && response != null) {
@@ -499,9 +431,9 @@ public class RestClient {
 			throws Exception {
 
 		String runCacheKey = null;
-		if (RunScopedMasterdataCache.isEnabled(contextKey) && RunScopedMasterdataCache.isCacheableGetUrl(url)) {
-			runCacheKey = RunScopedMasterdataCache.buildCacheKey(url, requestParams, pathParam);
-			JSONArray cached = RunScopedMasterdataCache.getCachedArray(contextKey, runCacheKey);
+		if (MasterdataCache.isEnabled(contextKey) && MasterdataCache.isCacheableGetUrl(url)) {
+			runCacheKey = MasterdataCache.buildGetKey(url, requestParams, pathParam);
+			JSONArray cached = MasterdataCache.getCachedGetArray(contextKey, runCacheKey);
 			if (cached != null) {
 				return cached;
 			}
@@ -518,17 +450,17 @@ public class RestClient {
 
 		while (!bDone) {
 
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			Map<String, Object> mapParam = requestParams == null ? null : requestParams.toMap();
 			Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 			if (isDebugEnabled(contextKey)) {
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 						.get(url, mapPathParam).then().log().all().extract().response();
 			} else {
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 						mapPathParam);
 			}
 
@@ -561,7 +493,7 @@ public class RestClient {
 
 		JSONArray result = new JSONObject(response.getBody().asString()).getJSONArray(dataKey);
 		if (runCacheKey != null) {
-			RunScopedMasterdataCache.putCachedArray(contextKey, runCacheKey, result);
+			MasterdataCache.putCachedGetArray(contextKey, runCacheKey, result);
 		}
 		return result;
 	}
@@ -572,7 +504,7 @@ public class RestClient {
 		if (!isValidToken(role, contextKey)) {
 			initPreregToken(url, requestParams, contextKey);
 		}
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 
@@ -582,10 +514,10 @@ public class RestClient {
 		Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 		if (isDebugEnabled(contextKey)) {
-			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+			response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 					.get(url, mapPathParam).then().log().all().extract().response();
 		} else {
-			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
+			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url, mapPathParam);
 		}
 
 		if (isDebugEnabled(contextKey) && response != null) {
@@ -617,24 +549,24 @@ public class RestClient {
 
 		Response response = null;
 
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (requestData != null) {
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).multiPart("file", new File(filePath))
+				response = requestSpec(contextKey).log().all().cookie(kukki).multiPart("file", new File(filePath))
 						.param("Document request", requestData.toString()).post(url).then().log().all().extract()
 						.response();
 			else
-				response = givenFiltered(contextKey).cookie(kukki).multiPart("file", new File(filePath))
+				response = requestSpec(contextKey).cookie(kukki).multiPart("file", new File(filePath))
 						.param("Document request", requestData.toString()).post(url);
 		} else {
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).multiPart("file", new File(filePath)).post(url).then()
+				response = requestSpec(contextKey).log().all().cookie(kukki).multiPart("file", new File(filePath)).post(url).then()
 						.log().all().extract().response();
 			else
-				response = givenFiltered(contextKey).cookie(kukki).multiPart("file", new File(filePath)).post(url);
+				response = requestSpec(contextKey).cookie(kukki).multiPart("file", new File(filePath)).post(url);
 		}
 		if (response == null) {
 			throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", url);
@@ -661,14 +593,14 @@ public class RestClient {
 
 		Response response = null;
 		RequestSpecification spec = null;
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			spec = givenFiltered(contextKey).log().all().cookie(kukki);
+			spec = requestSpec(contextKey).log().all().cookie(kukki);
 		else
-			spec = givenFiltered(contextKey).cookie(kukki);
+			spec = requestSpec(contextKey).cookie(kukki);
 		for (String fName : filePaths)
 			spec = spec.multiPart("files", new File(fName));
 		if (requestData != null) {
@@ -715,16 +647,16 @@ public class RestClient {
 
 		}
 
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 		logInfo(contextKey, "Request: " + jsonRequest.toString());
 		try {
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().contentType(ContentType.JSON).body(jsonRequest.toString()).post(url)
+				response = requestSpec(contextKey).log().all().contentType(ContentType.JSON).body(jsonRequest.toString()).post(url)
 						.then().log().all().extract().response();
 			else
-				response = givenFiltered(contextKey).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
+				response = requestSpec(contextKey).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
 		} catch (ServiceException se) {
 			throw se;
 		} catch (Exception e) {
@@ -746,7 +678,7 @@ public class RestClient {
 			String[] parts = cookie.split("=");
 			if (parts.length > 1) {
 				token = parts[1].split(";")[0];
-				tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+				AuthTokenStore.put(contextKey, role, token);
 			}
 
 		}
@@ -768,17 +700,17 @@ public class RestClient {
 
 		}
 
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 		logInfo(contextKey, "Request: " + jsonRequest.toString());
 		try {
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.post(url).then().log().all().extract().response();
 			else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
 
 			if (isDebugEnabled(contextKey)) {
 				if (response != null) {
@@ -798,7 +730,7 @@ public class RestClient {
 				String[] parts = cookie.split("=", 2);
 				if (parts.length > 1) {
 					token = parts[1].split(";")[0];
-					tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+					AuthTokenStore.put(contextKey, role, token);
 				}
 			}
 			logInfo(contextKey, token);
@@ -828,22 +760,22 @@ public class RestClient {
 			}
 
 		}
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 		logInfo(contextKey, "Request:" + jsonRequest.toString());
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.put(url).then().log().all().extract().response();
 		else
-			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 			token = cookie.split("=")[1];
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
 		logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -858,7 +790,7 @@ public class RestClient {
 		if (!isValidToken(role, contextKey)) {
 			initToken_admin(contextKey);
 		}
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 
@@ -866,15 +798,15 @@ public class RestClient {
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
+			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 			token = cookie.split("=")[1];
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
 		logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -889,21 +821,21 @@ public class RestClient {
 		if (!isValidToken(role, contextKey)) {
 			initToken_Resident(contextKey);
 		}
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 
 		logInfo(contextKey, "Request:" + jsonRequest.toString());
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 		if (isDebugEnabled(contextKey))
-			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
+			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 			token = cookie.split("=")[1];
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
 		logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -917,21 +849,21 @@ public class RestClient {
 		if (!isValidToken(role, contextKey)) {
 			initToken_Resident(contextKey);
 		}
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 
 		logInfo(contextKey, "Request:" + jsonRequest.toString());
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 		if (isDebugEnabled(contextKey))
-			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+			response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
+			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).delete(url);
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 			token = cookie.split("=")[1];
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
 		logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -946,7 +878,7 @@ public class RestClient {
 		if (!isValidToken(role, contextKey)) {
 			initToken_Resident(contextKey);
 		}
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 
 		Response response = null;
 
@@ -954,15 +886,15 @@ public class RestClient {
 		Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 
 		if (isDebugEnabled(contextKey))
-			response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap())
+			response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap())
 					.delete(url).then().log().all().extract().response();
 		else
-			response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap()).delete(url);
+			response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(jsonRequest.toMap()).delete(url);
 
 		String cookie = response.getHeader(SET_COOKIE);
 		if (cookie != null) {
 			token = cookie.split("=")[1];
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		logInfo(contextKey, token);
 		logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -978,10 +910,10 @@ public class RestClient {
 	public static Response post(String url, String requestBody, String contextKey) throws Exception {
 		Response response = null;
 		if (isDebugEnabled(contextKey))
-			response = givenFiltered(contextKey).log().all().baseUri(url).contentType(ContentType.JSON).and()
+			response = requestSpec(contextKey).log().all().baseUri(url).contentType(ContentType.JSON).and()
 					.body(requestBody).when().post().then().log().all().extract().response();
 		else
-			response = givenFiltered(contextKey).baseUri(url).contentType(ContentType.JSON).and().body(requestBody).when()
+			response = requestSpec(contextKey).baseUri(url).contentType(ContentType.JSON).and().body(requestBody).when()
 					.post().then().extract().response();
 
 		return response;
@@ -1007,15 +939,15 @@ public class RestClient {
 		Response response = null;
 
 		while (!bDone) {
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.post(url).then().log().all().extract().response();
 			else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).post(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1039,7 +971,7 @@ public class RestClient {
 
 			String token = cookie.split("=")[1];
 
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		if (response.getBody().asString().startsWith("{")) {
 			logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -1072,15 +1004,15 @@ public class RestClient {
 		Response response = null;
 
 		while (!bDone) {
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey)) {
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.put(url).then().log().all().extract().response();
 			} else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1097,7 +1029,7 @@ public class RestClient {
 		if (cookie != null) {
 
 			String token = cookie.split("=")[1];
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 
 		}
 
@@ -1138,7 +1070,7 @@ public class RestClient {
 				initToken(contextKey);
 			}
 		}
-		String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+		String token = AuthTokenStore.get(contextKey, role);
 		return token;
 
 	}
@@ -1153,15 +1085,15 @@ public class RestClient {
 		Response response = null;
 
 		while (!bDone) {
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey)) {
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.put(url).then().log().all().extract().response();
 			} else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1178,7 +1110,7 @@ public class RestClient {
 		if (cookie != null) {
 
 			String token = cookie.split("=")[1];
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 
 		}
 		if (response.getBody().asString().startsWith("{")) {
@@ -1200,15 +1132,15 @@ public class RestClient {
 		Response response = null;
 
 		while (!bDone) {
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey)) {
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.put(url).then().log().all().extract().response();
 			} else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).put(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1226,7 +1158,7 @@ public class RestClient {
 
 			String token = cookie.split("=")[1];
 
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		if (response.getBody().asString().startsWith("{")) {
 			logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -1247,15 +1179,15 @@ public class RestClient {
 		Response response = null;
 
 		while (!bDone) {
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			logInfo(contextKey, "Request:" + jsonRequest.toString());
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString())
 						.patch(url).then().log().all().extract().response();
 			else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).patch(url);
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).body(jsonRequest.toString()).patch(url);
 			if (response.getStatusCode() == 401 || response.getStatusCode() == 500) {
 				if (nLoop >= 1)
 					bDone = true;
@@ -1273,7 +1205,7 @@ public class RestClient {
 
 			String token = cookie.split("=")[1];
 
-			tokens.put(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role, token);
+			AuthTokenStore.put(contextKey, role, token);
 		}
 		if (response.getBody().asString().startsWith("{")) {
 			logInfo(contextKey, "Response:" + response.getBody().asString());
@@ -1293,10 +1225,10 @@ public class RestClient {
 			Response response = null;
 			try {
 				if (isDebugEnabled(contextKey))
-					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(url).then().log()
+					response = requestSpec(contextKey).log().all().contentType("application/json").body(jsonBody).post(url).then().log()
 							.all().extract().response();
 				else
-					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(url);
+					response = requestSpec(contextKey).contentType("application/json").body(jsonBody).post(url);
 			} catch (Exception e) {
 				logger.error(e.getMessage());
 			}
@@ -1319,347 +1251,29 @@ public class RestClient {
 		}
 	}
 
+
 	public static boolean initToken(String contextKey) {
-		try {
-
-			JSONObject requestBody = new JSONObject();
-			JSONObject nestedRequest = new JSONObject();
-			nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "admin_userName").toString());
-			nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, "admin_password").toString());
-			nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_admin_app_id").toString());
-			nestedRequest.put(CLIENTID,
-					VariableManager.getVariableValue(contextKey, "mosip_admin_client_id").toString());
-			nestedRequest.put("clientSecret",
-					VariableManager.getVariableValue(contextKey, "mosip_admin_client_secret").toString());
-			requestBody.put(METADATA, new JSONObject());
-			requestBody.put(VERSION, "1.0");
-			requestBody.put("id", "mosip.authentication.useridPwd");
-			requestBody.put(REQUESTTIME, CommonUtil.getUTCDateTime(LocalDateTime.now()).toString());
-			requestBody.put(REQUEST, nestedRequest);
-
-			String urlBase = VariableManager.getVariableValue(contextKey, URLBASE).toString().trim();
-			if (!shouldForceAuthRefresh(contextKey)) {
-				String cachedToken = getRunCachedAuthTokenForRequest(MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH,
-						nestedRequest, false, contextKey);
-				if (cachedToken != null && !cachedToken.isEmpty()) {
-					tokens.put(urlBase + SYSTEM, cachedToken);
-					return true;
-				}
-			}
-
-			String authUrl = urlBase
-					+ VariableManager.getVariableValue(VariableManager.NS_DEFAULT, "authManagerURL").toString().trim();
-			String jsonBody = requestBody.toString();
-			logInfo(contextKey, contextKey + " InitToken logger " + authUrl + AUTHURL + jsonBody);
-
-			Response response = null;
-			try {
-				if (isDebugEnabled(contextKey))
-					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
-							.log().all().extract().response();
-				else
-					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
-			} catch (Exception e) {
-				logger.error(e.getMessage());
-			}
-			if (response == null) {
-				throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", authUrl);
-			}
-			if (response != null) {
-				checkErrorResponse(response.getBody().asString(), authUrl);
-				if (response.getStatusCode() != 200 || response.toString().contains(ERRORCODE)) {
-					boolean bSlackit = VariableManager.getVariableValue(contextKey, POST2SLACK) == null ? false
-							: Boolean.parseBoolean(VariableManager.getVariableValue(contextKey, POST2SLACK).toString());
-					if (bSlackit)
-						SlackIt.postMessage(null, authUrl + " Failed to authenticate, Is "
-								+ VariableManager.getVariableValue(contextKey, URLBASE).toString() + " down ?");
-
-					return false;
-				}
-			}
-
-			String responseBody = response.getBody().asString();
-			String token = new JSONObject(responseBody).getJSONObject(dataKey).getString("token");
-			tokens.put(urlBase + SYSTEM, token);
-			cacheAuthTokenForRequest(MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH, nestedRequest, false, contextKey,
-					token);
-			return true;
-		} catch (Exception ex) {
-
-		}
-		return false;
-
+		return RestClientAuth.initToken(contextKey);
 	}
 
 	public static boolean initToken_admin(String contextKey) {
-		try {
-
-			JSONObject requestBody = new JSONObject();
-			JSONObject nestedRequest = new JSONObject();
-			nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "admin_userName").toString());
-			nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, "admin_password").toString());
-			nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_admin_app_id").toString());
-			nestedRequest.put(CLIENTID,
-					VariableManager.getVariableValue(contextKey, "mosip_admin_client_id").toString());
-			nestedRequest.put("clientSecret",
-					VariableManager.getVariableValue(contextKey, "mosip_admin_client_secret").toString());
-			requestBody.put(METADATA, new JSONObject());
-			requestBody.put(VERSION, "1.0");
-			requestBody.put("id", "mosip.authentication.useridPwd");
-			requestBody.put(REQUESTTIME, CommonUtil.getUTCDateTime(LocalDateTime.now()).toString());
-			requestBody.put(REQUEST, nestedRequest);
-
-			String urlBase = VariableManager.getVariableValue(contextKey, URLBASE).toString().trim();
-			if (!shouldForceAuthRefresh(contextKey)) {
-				String cachedToken = getRunCachedAuthTokenForRequest(MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH,
-						nestedRequest, false, contextKey);
-				if (cachedToken != null && !cachedToken.isEmpty()) {
-					tokens.put(urlBase + ADMIN, cachedToken);
-					return true;
-				}
-			}
-
-			String authUrl = urlBase
-					+ VariableManager.getVariableValue(VariableManager.NS_DEFAULT, "authManagerURL").toString().trim();
-			String jsonBody = requestBody.toString();
-			logInfo(contextKey, contextKey + " InitToken_admin logger " + authUrl + AUTHURL + jsonBody);
-			Response response = null;
-			try {
-				if (isDebugEnabled(contextKey))
-					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
-							.log().all().extract().response();
-				else
-					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
-
-			} catch (Exception e) {
-				logger.error(e.getMessage());
-			}
-			if (response == null) {
-				throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", authUrl);
-			}
-			checkErrorResponse(response.getBody().asString(), authUrl);
-			if (response != null && (response.getStatusCode() != 200 || response.toString().contains(ERRORCODE))) {
-				boolean bSlackit = VariableManager.getVariableValue(contextKey, POST2SLACK) == null ? false
-						: Boolean.parseBoolean(VariableManager.getVariableValue(contextKey, POST2SLACK).toString());
-				if (bSlackit)
-					SlackIt.postMessage(null, authUrl + " Failed to authenticate, Is "
-							+ VariableManager.getVariableValue(contextKey, URLBASE).toString() + " down ?");
-
-				return false;
-			}
-			String responseBody = response.getBody().asString();
-			String token = new JSONObject(responseBody).getJSONObject(dataKey).getString("token");
-
-			tokens.put(urlBase + ADMIN, token);
-			cacheAuthTokenForRequest(MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH, nestedRequest, false, contextKey,
-					token);
-
-			return true;
-		} catch (Exception ex) {
-
-		}
-		return false;
-
+		return RestClientAuth.initToken_admin(contextKey);
 	}
 
 	public static boolean initToken_Resident(String contextKey) {
-		try {
-			JSONObject requestBody = new JSONObject();
-			JSONObject nestedRequest = new JSONObject();
-			nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "operatorId"));
-			nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, PASSWORD));
-			nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_resident_app_id"));
-			nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_resident_client_id"));
-			nestedRequest.put("secretKey",
-					VariableManager.getVariableValue(contextKey, "mosip_resident_client_secret"));
-			requestBody.put(METADATA, new JSONObject());
-			requestBody.put(VERSION, "string");
-			requestBody.put("id", "string");
-			requestBody.put(REQUESTTIME, CommonUtil.getUTCDateTime(LocalDateTime.now()).toString());
-			requestBody.put(REQUEST, nestedRequest);
-
-			String urlBase = VariableManager.getVariableValue(contextKey, URLBASE).toString().trim();
-			if (!shouldForceAuthRefresh(contextKey)) {
-				String cachedToken = getRunCachedAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH,
-						nestedRequest, true, contextKey);
-				if (cachedToken != null && !cachedToken.isEmpty()) {
-					tokens.put(urlBase + RESIDENT, cachedToken);
-					return true;
-				}
-			}
-
-			String authUrl = urlBase + MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH;
-
-			String jsonBody = requestBody.toString();
-			logInfo(contextKey, contextKey + " initToken_Resident logger " + authUrl + AUTHURL + jsonBody);
-
-			Response response = null;
-			try {
-				if (isDebugEnabled(contextKey))
-					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
-							.log().all().extract().response();
-				else
-					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
-			} catch (Exception e) {
-				logger.error(e.getMessage());
-			}
-			if (response == null) {
-				throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", authUrl);
-			}
-			checkErrorResponse(response.getBody().asString(), authUrl);
-			if (response != null && (response.getStatusCode() != 200 || response.toString().contains(ERRORCODE))) {
-				boolean bSlackit = VariableManager.getVariableValue(contextKey, POST2SLACK) == null ? false
-						: Boolean.parseBoolean(VariableManager.getVariableValue(contextKey, POST2SLACK).toString());
-				if (bSlackit)
-					SlackIt.postMessage(null, authUrl + " Failed to authenticate, Is "
-							+ VariableManager.getVariableValue(contextKey, URLBASE).toString() + " down ?");
-
-				return false;
-			}
-			String token = response.getCookie(AUTHORIZATION);
-			tokens.put(urlBase + RESIDENT, token);
-			cacheAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH, nestedRequest, true, contextKey,
-					token);
-
-			return true;
-		} catch (Exception ex) {
-
-		}
-		return false;
-
+		return RestClientAuth.initToken_Resident(contextKey);
 	}
 
 	public static boolean initToken_Regproc(String contextKey) {
-		try {
-			JSONObject requestBody = new JSONObject();
-			JSONObject nestedRequest = new JSONObject();
-			nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "operatorId"));
-			nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, PASSWORD));
-			nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_regprocclient_app_id"));
-			nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_regproc_client_id"));
-			nestedRequest.put("secretKey", VariableManager.getVariableValue(contextKey, "mosip_regproc_client_secret"));
-			requestBody.put(METADATA, new JSONObject());
-			requestBody.put(VERSION, "string");
-			requestBody.put("id", "string");
-			requestBody.put(REQUESTTIME, CommonUtil.getUTCDateTime(LocalDateTime.now()).toString());
-			requestBody.put(REQUEST, nestedRequest);
-
-			String urlBase = VariableManager.getVariableValue(contextKey, URLBASE).toString().trim();
-			if (!shouldForceAuthRefresh(contextKey)) {
-				String cachedToken = getRunCachedAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH,
-						nestedRequest, true, contextKey);
-				if (cachedToken != null && !cachedToken.isEmpty()) {
-					tokens.put(urlBase + REGPROC, cachedToken);
-					return true;
-				}
-			}
-
-			String authUrl = urlBase + MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH;
-
-			String jsonBody = requestBody.toString();
-			logInfo(contextKey, contextKey + " initToken_Resident logger " + authUrl + AUTHURL + jsonBody);
-
-			Response response = null;
-			try {
-				if (isDebugEnabled(contextKey))
-					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
-							.log().all().extract().response();
-				else
-					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
-			} catch (Exception e) {
-				logger.error(e.getMessage());
-			}
-			if (response == null) {
-				throw new ServiceException(HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", authUrl);
-			}
-			checkErrorResponse(response.getBody().asString(), authUrl);
-			if (response != null && (response.getStatusCode() != 200 || response.toString().contains(ERRORCODE))) {
-				boolean bSlackit = VariableManager.getVariableValue(contextKey, POST2SLACK) == null ? false
-						: Boolean.parseBoolean(VariableManager.getVariableValue(contextKey, POST2SLACK).toString());
-				if (bSlackit)
-					SlackIt.postMessage(null, authUrl + " Failed to authenticate, Is "
-							+ VariableManager.getVariableValue(contextKey, URLBASE).toString() + " down ?");
-
-				return false;
-			}
-			String token = response.getCookie(AUTHORIZATION);
-			tokens.put(urlBase + REGPROC, token);
-			cacheAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH, nestedRequest, true, contextKey,
-					token);
-
-			return true;
-		} catch (Exception ex) {
-
-		}
-
-		return false;
-
+		return RestClientAuth.initToken_Regproc(contextKey);
 	}
 
 	public static boolean initToken_crvs1(String contextKey) {
-		try {
-			JSONObject requestBody = new JSONObject();
-			JSONObject nestedRequest = new JSONObject();
-			nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "operatorId"));
-			nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, PASSWORD));
-			nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_crvs1_app_id"));
-			nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_crvs1_client_id"));
-			nestedRequest.put("secretKey", VariableManager.getVariableValue(contextKey, "mosip_crvs1_client_secret"));
-			requestBody.put(METADATA, new JSONObject());
-			requestBody.put(VERSION, "string");
-			requestBody.put("id", "string");
-			requestBody.put(REQUESTTIME, CommonUtil.getUTCDateTime(LocalDateTime.now()).toString());
-			requestBody.put(REQUEST, nestedRequest);
-
-			String urlBase = VariableManager.getVariableValue(contextKey, URLBASE).toString().trim();
-			if (!shouldForceAuthRefresh(contextKey)) {
-				String cachedToken = getRunCachedAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH,
-						nestedRequest, true, contextKey);
-				if (cachedToken != null && !cachedToken.isEmpty()) {
-					tokens.put(urlBase + CRVS, cachedToken);
-					return true;
-				}
-			}
-
-			String authUrl = urlBase + MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH;
-
-			String jsonBody = requestBody.toString();
-			logInfo(contextKey, contextKey + " initToken_Resident logger " + authUrl + AUTHURL + jsonBody);
-
-			Response response = null;
-			try {
-				if (isDebugEnabled(contextKey))
-					response = givenFiltered(contextKey).log().all().contentType("application/json").body(jsonBody).post(authUrl).then()
-							.log().all().extract().response();
-				else
-					response = givenFiltered(contextKey).contentType("application/json").body(jsonBody).post(authUrl);
-			} catch (Exception e) {
-				logger.error(e.getMessage());
-			}
-
-			if (response != null && (response.getStatusCode() != 200 || response.toString().contains(ERRORCODE))) {
-				boolean bSlackit = VariableManager.getVariableValue(contextKey, POST2SLACK) == null ? false
-						: Boolean.parseBoolean(VariableManager.getVariableValue(contextKey, POST2SLACK).toString());
-				if (bSlackit)
-					SlackIt.postMessage(null, authUrl + " Failed to authenticate, Is "
-							+ VariableManager.getVariableValue(contextKey, URLBASE).toString() + " down ?");
-
-				return false;
-			}
-			String token = response.getCookie(AUTHORIZATION);
-			tokens.put(urlBase + CRVS, token);
-			cacheAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH, nestedRequest, true, contextKey,
-					token);
-			checkErrorResponse(response.getBody().asString(), authUrl);
-			return true;
-		} catch (Exception ex) {
-
-		}
-		return false;
-
+		return RestClientAuth.initToken_crvs1(contextKey);
 	}
 
-	private static void checkErrorResponse(String response, String url) {
+
+	static void checkErrorResponse(String response, String url) {
 
 
 		if (response == null || response.trim().isEmpty()) {
@@ -1767,18 +1381,18 @@ public class RestClient {
 
 		while (!bDone) {
 
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			Map<String, Object> mapParam = requestParams == null ? null : requestParams.toMap();
 			Map<String, Object> mapPathParam = pathParam == null ? null : pathParam.toMap();
 
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam)
 						.get(url, mapPathParam).then().log().all().extract().response();
 
 			else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).queryParams(mapParam).get(url,
 						mapPathParam);
 
 			if (response.getStatusCode() == 401) {
@@ -1849,14 +1463,14 @@ public class RestClient {
 
 		while (!bDone) {
 
-			String token = tokens.get(VariableManager.getVariableValue(contextKey, URLBASE).toString().trim() + role);
+			String token = AuthTokenStore.get(contextKey, role);
 
 			Cookie kukki = new Cookie.Builder(AUTHORIZATION, token).build();
 			if (isDebugEnabled(contextKey))
-				response = givenFiltered(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).get(urlAct).then().log().all()
+				response = requestSpec(contextKey).log().all().cookie(kukki).contentType(ContentType.JSON).get(urlAct).then().log().all()
 						.extract().response();
 			else
-				response = givenFiltered(contextKey).cookie(kukki).contentType(ContentType.JSON).get(urlAct);
+				response = requestSpec(contextKey).cookie(kukki).contentType(ContentType.JSON).get(urlAct);
 
 			if (response.getStatusCode() == 401) {
 				if (nLoop >= 1)
@@ -1889,10 +1503,10 @@ public class RestClient {
 
 		Response response = null;
 		if (isDebugEnabled(contextKey))
-			response = givenFiltered(contextKey).log().all().contentType(ContentType.JSON).get(urlAct).then().log().all().extract()
+			response = requestSpec(contextKey).log().all().contentType(ContentType.JSON).get(urlAct).then().log().all().extract()
 					.response();
 		else
-			response = givenFiltered(contextKey).contentType(ContentType.JSON).get(urlAct);
+			response = requestSpec(contextKey).contentType(ContentType.JSON).get(urlAct);
 
 		if (response != null && response.getStatusCode() == 200) {
 			checkErrorResponse(response.getBody().asString(), urlAct);
@@ -1906,117 +1520,6 @@ public class RestClient {
 			return false;
 		} else
 			return false;
-	}
-
-	private static boolean isClientSecretAuthRole(String role) {
-		return RESIDENT.equals(role) || REGPROC.equals(role) || CRVS.equals(role);
-	}
-
-	private static void appendJsonField(StringBuilder sb, JSONObject nestedRequest, String key) {
-		if (nestedRequest.has(key) && !nestedRequest.isNull(key)) {
-			sb.append(key).append('=').append(nestedRequest.get(key)).append(';');
-		}
-	}
-
-	private static String credFingerprint(JSONObject nestedRequest, boolean clientSecretAuth) {
-		StringBuilder sb = new StringBuilder();
-		appendJsonField(sb, nestedRequest, USERNAME);
-		appendJsonField(sb, nestedRequest, PASSWORD);
-		appendJsonField(sb, nestedRequest, APPID);
-		appendJsonField(sb, nestedRequest, CLIENTID);
-		if (clientSecretAuth) {
-			appendJsonField(sb, nestedRequest, "secretKey");
-		}
-		appendJsonField(sb, nestedRequest, "clientSecret");
-		return Integer.toHexString(sb.toString().hashCode());
-	}
-
-	private static String getRunCachedAuthTokenForRequest(String authPath, JSONObject nestedRequest,
-			boolean clientSecretAuth, String contextKey) {
-		String cacheKey = MosipDataSetup.authCacheKey(authPath, credFingerprint(nestedRequest, clientSecretAuth));
-		Object cached = MosipDataSetup.getCache(cacheKey, MosipDataSetup.getRunContextNamespace(contextKey));
-		return cached instanceof String ? (String) cached : null;
-	}
-
-	private static void cacheAuthTokenForRequest(String authPath, JSONObject nestedRequest, boolean clientSecretAuth,
-			String contextKey, String token) {
-		if (token == null || token.isEmpty()) {
-			return;
-		}
-		String cacheKey = MosipDataSetup.authCacheKey(authPath, credFingerprint(nestedRequest, clientSecretAuth));
-		MosipDataSetup.setCache(cacheKey, token, MosipDataSetup.getRunContextNamespace(contextKey));
-	}
-
-	private static JSONObject buildNestedRequestForRole(String role, String contextKey) {
-		JSONObject nestedRequest = new JSONObject();
-		try {
-			if (ADMIN.equals(role) || SYSTEM.equals(role)) {
-				nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "admin_userName").toString());
-				nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, "admin_password").toString());
-				nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_admin_app_id").toString());
-				nestedRequest.put(CLIENTID,
-						VariableManager.getVariableValue(contextKey, "mosip_admin_client_id").toString());
-				nestedRequest.put("clientSecret",
-						VariableManager.getVariableValue(contextKey, "mosip_admin_client_secret").toString());
-				return nestedRequest;
-			}
-			if (RESIDENT.equals(role)) {
-				nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "operatorId"));
-				nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, PASSWORD));
-				nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_resident_app_id"));
-				nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_resident_client_id"));
-				nestedRequest.put("secretKey",
-						VariableManager.getVariableValue(contextKey, "mosip_resident_client_secret"));
-				return nestedRequest;
-			}
-			if (REGPROC.equals(role)) {
-				nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "operatorId"));
-				nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, PASSWORD));
-				nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_regprocclient_app_id"));
-				nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_regproc_client_id"));
-				nestedRequest.put("secretKey",
-						VariableManager.getVariableValue(contextKey, "mosip_regproc_client_secret"));
-				return nestedRequest;
-			}
-			if (CRVS.equals(role)) {
-				nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "operatorId"));
-				nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, PASSWORD));
-				nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_crvs1_app_id"));
-				nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_crvs1_client_id"));
-				nestedRequest.put("secretKey",
-						VariableManager.getVariableValue(contextKey, "mosip_crvs1_client_secret"));
-				return nestedRequest;
-			}
-		} catch (Exception e) {
-			logger.debug("Could not build auth request for role {}: {}", role, e.getMessage());
-		}
-		return null;
-	}
-
-	private static String getRunCachedAuthTokenForRole(String role, String contextKey) {
-		JSONObject nestedRequest = buildNestedRequestForRole(role, contextKey);
-		if (nestedRequest == null) {
-			return null;
-		}
-		boolean clientSecretAuth = isClientSecretAuthRole(role);
-		String authPath = clientSecretAuth ? MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH
-				: MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH;
-		return getRunCachedAuthTokenForRequest(authPath, nestedRequest, clientSecretAuth, contextKey);
-	}
-
-	private static void restoreAuthTokenFromRunCache(String role, String contextKey) {
-		String token = getRunCachedAuthTokenForRole(role, contextKey);
-		if (token == null || token.isEmpty()) {
-			return;
-		}
-		try {
-			Object urlBase = VariableManager.getVariableValue(contextKey, URLBASE);
-			if (urlBase != null) {
-				tokens.put(urlBase.toString().trim() + role, token);
-			}
-		} catch (Exception e) {
-			logger.debug("Could not restore auth token for role {}: {}", role, e.getMessage());
-		}
 	}
 
 }

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClientAuth.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClientAuth.java
@@ -1,0 +1,335 @@
+package io.mosip.testrig.dslrig.dataprovider.util;
+
+import java.time.LocalDateTime;
+
+import org.json.JSONObject;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import io.mosip.testrig.dslrig.dataprovider.preparation.MosipDataSetup;
+import io.mosip.testrig.dslrig.dataprovider.variables.VariableManager;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+/**
+ * MOSIP auth token acquisition and validation (extracted from {@link RestClient}).
+ */
+public final class RestClientAuth {
+
+	private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RestClientAuth.class);
+
+	private static final String URLBASE = "urlBase";
+	private static final String AUTHORIZATION = "Authorization";
+	private static final String USERNAME = "userName";
+	private static final String PASSWORD = "password";
+	private static final String APPID = "appId";
+	private static final String CLIENTID = "clientId";
+	private static final String METADATA = "metadata";
+	private static final String VERSION = "version";
+	private static final String REQUESTTIME = "requesttime";
+	private static final String REQUEST = "request";
+	private static final String AUTHURL = " Auth URL";
+	private static final String POST2SLACK = "post2slack";
+	private static final String ERRORCODE = "errorCode";
+	private static final String DATA_KEY = "response";
+
+	private RestClientAuth() {
+	}
+
+	public static boolean isValidToken(String role, String contextKey) {
+		if (shouldForceAuthRefresh(contextKey)) {
+			return false;
+		}
+		try {
+			Object urlBase = VariableManager.getVariableValue(contextKey, URLBASE);
+			if (urlBase == null) {
+				return false;
+			}
+			String token = AuthTokenStore.get(contextKey, role);
+			if (token == null || token.isEmpty()) {
+				restoreAuthTokenFromRunCache(role, contextKey);
+				token = AuthTokenStore.get(contextKey, role);
+			}
+			return token != null && !token.isEmpty() && isValidTokenOffline(token, contextKey);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	public static boolean isValidTokenOffline(String cookie, String contextKey) {
+		if (cookie == null) {
+			return false;
+		}
+		try {
+			DecodedJWT decodedJWT = JWT.decode(cookie);
+			long expirationTime = decodedJWT.getExpiresAt().getTime();
+			if (expirationTime < System.currentTimeMillis()) {
+				RestClient.logInfo(contextKey, "The token is expired");
+				return false;
+			}
+			RestClient.logInfo(contextKey, "The token is not expired");
+			return true;
+		} catch (JWTDecodeException e) {
+			logger.error("The token is invalid");
+			return false;
+		}
+	}
+
+	public static boolean initToken(String contextKey) {
+		return authenticateInternal(contextKey, AuthTokenStore.ROLE_SYSTEM, "mosip.authentication.useridPwd");
+	}
+
+	public static boolean initToken_admin(String contextKey) {
+		return authenticateInternal(contextKey, AuthTokenStore.ROLE_ADMIN, "mosip.authentication.useridPwd");
+	}
+
+	public static boolean initToken_Resident(String contextKey) {
+		try {
+			return authenticateClientSecret(contextKey, AuthTokenStore.ROLE_RESIDENT,
+					buildClientSecretRequest(contextKey, "mosip_resident_app_id", "mosip_resident_client_id",
+							"mosip_resident_client_secret"));
+		} catch (Exception ex) {
+			logger.debug("initToken_Resident failed: {}", ex.getMessage());
+			return false;
+		}
+	}
+
+	public static boolean initToken_Regproc(String contextKey) {
+		try {
+			return authenticateClientSecret(contextKey, AuthTokenStore.ROLE_REGPROC,
+					buildClientSecretRequest(contextKey, "mosip_regprocclient_app_id", "mosip_regproc_client_id",
+							"mosip_regproc_client_secret"));
+		} catch (Exception ex) {
+			logger.debug("initToken_Regproc failed: {}", ex.getMessage());
+			return false;
+		}
+	}
+
+	public static boolean initToken_crvs1(String contextKey) {
+		try {
+			return authenticateClientSecret(contextKey, AuthTokenStore.ROLE_CRVS,
+					buildClientSecretRequest(contextKey, "mosip_crvs1_app_id", "mosip_crvs1_client_id",
+							"mosip_crvs1_client_secret"));
+		} catch (Exception ex) {
+			logger.debug("initToken_crvs1 failed: {}", ex.getMessage());
+			return false;
+		}
+	}
+
+	private static boolean authenticateInternal(String contextKey, String role, String requestId) {
+		try {
+			JSONObject nestedRequest = buildAdminNestedRequest(contextKey);
+			JSONObject requestBody = wrapAuthRequest(nestedRequest, requestId, new JSONObject());
+
+			if (!shouldForceAuthRefresh(contextKey)) {
+				String cached = getRunCachedAuthTokenForRequest(MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH,
+						nestedRequest, false, contextKey);
+				if (cached != null && !cached.isEmpty()) {
+					AuthTokenStore.put(contextKey, role, cached);
+					return true;
+				}
+			}
+
+			String authUrl = VariableManager.getVariableValue(contextKey, URLBASE).toString().trim()
+					+ VariableManager.getVariableValue(VariableManager.NS_DEFAULT, "authManagerURL").toString().trim();
+			Response response = postJson(contextKey, authUrl, requestBody.toString());
+			if (response.getStatusCode() != 200 || response.toString().contains(ERRORCODE)) {
+				notifyAuthFailure(contextKey, authUrl);
+				return false;
+			}
+			String token = new JSONObject(response.getBody().asString()).getJSONObject(DATA_KEY).getString("token");
+			AuthTokenStore.put(contextKey, role, token);
+			cacheAuthTokenForRequest(MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH, nestedRequest, false, contextKey,
+					token);
+			return true;
+		} catch (Exception ex) {
+			logger.debug("authenticateInternal failed for role {}: {}", role, ex.getMessage());
+			return false;
+		}
+	}
+
+	private static boolean authenticateClientSecret(String contextKey, String role, JSONObject nestedRequest) {
+		try {
+			JSONObject requestBody = wrapAuthRequest(nestedRequest, "string", new JSONObject());
+
+			if (!shouldForceAuthRefresh(contextKey)) {
+				String cached = getRunCachedAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH,
+						nestedRequest, true, contextKey);
+				if (cached != null && !cached.isEmpty()) {
+					AuthTokenStore.put(contextKey, role, cached);
+					return true;
+				}
+			}
+
+			String authUrl = VariableManager.getVariableValue(contextKey, URLBASE).toString().trim()
+					+ MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH;
+			Response response = postJson(contextKey, authUrl, requestBody.toString());
+			if (response == null || response.getStatusCode() != 200 || response.toString().contains(ERRORCODE)) {
+				notifyAuthFailure(contextKey, authUrl);
+				return false;
+			}
+			String token = response.getCookie(AUTHORIZATION);
+			AuthTokenStore.put(contextKey, role, token);
+			cacheAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH, nestedRequest, true, contextKey, token);
+			RestClient.checkErrorResponse(response.getBody().asString(), authUrl);
+			return true;
+		} catch (Exception ex) {
+			logger.debug("authenticateClientSecret failed for role {}: {}", role, ex.getMessage());
+			return false;
+		}
+	}
+
+	private static JSONObject buildAdminNestedRequest(String contextKey) throws Exception {
+		JSONObject nestedRequest = new JSONObject();
+		nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "admin_userName").toString());
+		nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, "admin_password").toString());
+		nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_admin_app_id").toString());
+		nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_admin_client_id").toString());
+		nestedRequest.put("clientSecret",
+				VariableManager.getVariableValue(contextKey, "mosip_admin_client_secret").toString());
+		return nestedRequest;
+	}
+
+	private static JSONObject buildClientSecretRequest(String contextKey, String appIdKey, String clientIdKey,
+			String secretKey) throws Exception {
+		JSONObject nestedRequest = new JSONObject();
+		nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "operatorId"));
+		nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, PASSWORD));
+		nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, appIdKey));
+		nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, clientIdKey));
+		nestedRequest.put("secretKey", VariableManager.getVariableValue(contextKey, secretKey));
+		return nestedRequest;
+	}
+
+	private static JSONObject wrapAuthRequest(JSONObject nestedRequest, String requestId, Object metadata) {
+		JSONObject requestBody = new JSONObject();
+		requestBody.put(METADATA, metadata);
+		requestBody.put(VERSION, metadata instanceof JSONObject ? "1.0" : "string");
+		requestBody.put("id", requestId);
+		requestBody.put(REQUESTTIME, CommonUtil.getUTCDateTime(LocalDateTime.now()).toString());
+		requestBody.put(REQUEST, nestedRequest);
+		return requestBody;
+	}
+
+	private static Response postJson(String contextKey, String authUrl, String jsonBody) throws Exception {
+		RestClient.logInfo(contextKey, contextKey + AUTHURL + authUrl + jsonBody);
+		RequestSpecification spec = RestClient.requestSpec(contextKey).contentType("application/json").body(jsonBody);
+		if (RestClient.isDebugEnabled(contextKey)) {
+			return spec.log().all().post(authUrl).then().log().all().extract().response();
+		}
+		Response response = spec.post(authUrl);
+		if (response == null) {
+			throw new ServiceException(org.springframework.http.HttpStatus.BAD_GATEWAY, "REST_NO_RESPONSE", authUrl);
+		}
+		RestClient.checkErrorResponse(response.getBody().asString(), authUrl);
+		return response;
+	}
+
+	private static void notifyAuthFailure(String contextKey, String authUrl) {
+		try {
+			boolean slack = VariableManager.getVariableValue(contextKey, POST2SLACK) != null
+					&& Boolean.parseBoolean(VariableManager.getVariableValue(contextKey, POST2SLACK).toString());
+			if (slack) {
+				SlackIt.postMessage(null, authUrl + " Failed to authenticate, Is "
+						+ VariableManager.getVariableValue(contextKey, URLBASE).toString() + " down ?");
+			}
+		} catch (Exception ignored) {
+			// optional notification
+		}
+	}
+
+	private static boolean shouldForceAuthRefresh(String contextKey) {
+		try {
+			Object obj = VariableManager.getVariableValue(contextKey, "urlSwitched");
+			if (obj != null) {
+				return Boolean.parseBoolean(obj.toString());
+			}
+		} catch (Exception ignored) {
+			// allow run-cache reuse
+		}
+		return false;
+	}
+
+	private static void restoreAuthTokenFromRunCache(String role, String contextKey) {
+		String token = getRunCachedAuthTokenForRole(role, contextKey);
+		if (token != null && !token.isEmpty()) {
+			AuthTokenStore.put(contextKey, role, token);
+		}
+	}
+
+	private static String getRunCachedAuthTokenForRole(String role, String contextKey) {
+		JSONObject nestedRequest = buildNestedRequestForRole(role, contextKey);
+		if (nestedRequest == null) {
+			return null;
+		}
+		boolean clientSecretAuth = isClientSecretAuthRole(role);
+		String authPath = clientSecretAuth ? MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH
+				: MosipDataSetup.AUTH_INTERNAL_USERID_PWD_PATH;
+		return getRunCachedAuthTokenForRequest(authPath, nestedRequest, clientSecretAuth, contextKey);
+	}
+
+	private static boolean isClientSecretAuthRole(String role) {
+		return AuthTokenStore.ROLE_RESIDENT.equals(role) || AuthTokenStore.ROLE_REGPROC.equals(role)
+				|| AuthTokenStore.ROLE_CRVS.equals(role);
+	}
+
+	private static JSONObject buildNestedRequestForRole(String role, String contextKey) {
+		try {
+			if (AuthTokenStore.ROLE_ADMIN.equals(role) || AuthTokenStore.ROLE_SYSTEM.equals(role)) {
+				return buildAdminNestedRequest(contextKey);
+			}
+			if (AuthTokenStore.ROLE_RESIDENT.equals(role)) {
+				return buildClientSecretRequest(contextKey, "mosip_resident_app_id", "mosip_resident_client_id",
+						"mosip_resident_client_secret");
+			}
+			if (AuthTokenStore.ROLE_REGPROC.equals(role)) {
+				return buildClientSecretRequest(contextKey, "mosip_regprocclient_app_id", "mosip_regproc_client_id",
+						"mosip_regproc_client_secret");
+			}
+			if (AuthTokenStore.ROLE_CRVS.equals(role)) {
+				return buildClientSecretRequest(contextKey, "mosip_crvs1_app_id", "mosip_crvs1_client_id",
+						"mosip_crvs1_client_secret");
+			}
+		} catch (Exception e) {
+			logger.debug("Could not build auth request for role {}: {}", role, e.getMessage());
+		}
+		return null;
+	}
+
+	private static String getRunCachedAuthTokenForRequest(String authPath, JSONObject nestedRequest,
+			boolean clientSecretAuth, String contextKey) {
+		String cacheKey = MosipDataSetup.authCacheKey(authPath, credFingerprint(nestedRequest, clientSecretAuth));
+		Object cached = MosipDataSetup.getCache(cacheKey, MosipDataSetup.getRunContextNamespace(contextKey));
+		return cached instanceof String ? (String) cached : null;
+	}
+
+	private static void cacheAuthTokenForRequest(String authPath, JSONObject nestedRequest, boolean clientSecretAuth,
+			String contextKey, String token) {
+		if (token == null || token.isEmpty()) {
+			return;
+		}
+		String cacheKey = MosipDataSetup.authCacheKey(authPath, credFingerprint(nestedRequest, clientSecretAuth));
+		MosipDataSetup.setCache(cacheKey, token, MosipDataSetup.getRunContextNamespace(contextKey));
+	}
+
+	private static String credFingerprint(JSONObject nestedRequest, boolean clientSecretAuth) {
+		StringBuilder sb = new StringBuilder();
+		appendJsonField(sb, nestedRequest, USERNAME);
+		appendJsonField(sb, nestedRequest, PASSWORD);
+		appendJsonField(sb, nestedRequest, APPID);
+		appendJsonField(sb, nestedRequest, CLIENTID);
+		if (clientSecretAuth) {
+			appendJsonField(sb, nestedRequest, "secretKey");
+		}
+		appendJsonField(sb, nestedRequest, "clientSecret");
+		return Integer.toHexString(sb.toString().hashCode());
+	}
+
+	private static void appendJsonField(StringBuilder sb, JSONObject nestedRequest, String key) {
+		if (nestedRequest.has(key) && !nestedRequest.isNull(key)) {
+			sb.append(key).append('=').append(nestedRequest.get(key)).append(';');
+		}
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClientAuth.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/util/RestClientAuth.java
@@ -120,7 +120,8 @@ public final class RestClientAuth {
 
 	private static boolean authenticateInternal(String contextKey, String role, String requestId) {
 		try {
-			JSONObject nestedRequest = buildAdminNestedRequest(contextKey);
+			boolean systemPrincipal = AuthTokenStore.ROLE_SYSTEM.equals(role);
+			JSONObject nestedRequest = buildInternalNestedRequest(contextKey, systemPrincipal);
 			JSONObject requestBody = wrapAuthRequest(nestedRequest, requestId, new JSONObject());
 
 			if (!shouldForceAuthRefresh(contextKey)) {
@@ -171,6 +172,10 @@ public final class RestClientAuth {
 				return false;
 			}
 			String token = response.getCookie(AUTHORIZATION);
+			if (token == null || token.isBlank()) {
+				notifyAuthFailure(contextKey, authUrl);
+				return false;
+			}
 			AuthTokenStore.put(contextKey, role, token);
 			cacheAuthTokenForRequest(MosipDataSetup.AUTH_CLIENT_ID_SECRET_PATH, nestedRequest, true, contextKey, token);
 			RestClient.checkErrorResponse(response.getBody().asString(), authUrl);
@@ -181,15 +186,38 @@ public final class RestClientAuth {
 		}
 	}
 
-	private static JSONObject buildAdminNestedRequest(String contextKey) throws Exception {
+	private static JSONObject buildInternalNestedRequest(String contextKey, boolean systemPrincipal)
+			throws Exception {
 		JSONObject nestedRequest = new JSONObject();
-		nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "admin_userName").toString());
-		nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, "admin_password").toString());
-		nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_admin_app_id").toString());
-		nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_admin_client_id").toString());
-		nestedRequest.put("clientSecret",
-				VariableManager.getVariableValue(contextKey, "mosip_admin_client_secret").toString());
+		if (systemPrincipal) {
+			nestedRequest.put(USERNAME, variableOrFallback(contextKey, "system_userName", "admin_userName"));
+			nestedRequest.put(PASSWORD, variableOrFallback(contextKey, "system_password", "admin_password"));
+			nestedRequest.put(APPID, variableOrFallback(contextKey, "mosip_system_app_id", "mosip_admin_app_id"));
+			nestedRequest.put(CLIENTID, variableOrFallback(contextKey, "mosip_system_client_id", "mosip_admin_client_id"));
+			nestedRequest.put("clientSecret",
+					variableOrFallback(contextKey, "mosip_system_client_secret", "mosip_admin_client_secret"));
+		} else {
+			nestedRequest.put(USERNAME, VariableManager.getVariableValue(contextKey, "admin_userName").toString());
+			nestedRequest.put(PASSWORD, VariableManager.getVariableValue(contextKey, "admin_password").toString());
+			nestedRequest.put(APPID, VariableManager.getVariableValue(contextKey, "mosip_admin_app_id").toString());
+			nestedRequest.put(CLIENTID, VariableManager.getVariableValue(contextKey, "mosip_admin_client_id").toString());
+			nestedRequest.put("clientSecret",
+					VariableManager.getVariableValue(contextKey, "mosip_admin_client_secret").toString());
+		}
 		return nestedRequest;
+	}
+
+	private static String variableOrFallback(String contextKey, String primaryKey, String fallbackKey)
+			throws Exception {
+		try {
+			Object value = VariableManager.getVariableValue(contextKey, primaryKey);
+			if (value != null && !value.toString().isBlank()) {
+				return value.toString();
+			}
+		} catch (Exception ignored) {
+			// use admin fallback keys
+		}
+		return VariableManager.getVariableValue(contextKey, fallbackKey).toString();
 	}
 
 	private static JSONObject buildClientSecretRequest(String contextKey, String appIdKey, String clientIdKey,
@@ -214,7 +242,7 @@ public final class RestClientAuth {
 	}
 
 	private static Response postJson(String contextKey, String authUrl, String jsonBody) throws Exception {
-		RestClient.logInfo(contextKey, contextKey + AUTHURL + authUrl + jsonBody);
+		RestClient.logInfo(contextKey, contextKey + AUTHURL + authUrl + " [auth credentials redacted]");
 		RequestSpecification spec = RestClient.requestSpec(contextKey).contentType("application/json").body(jsonBody);
 		if (RestClient.isDebugEnabled(contextKey)) {
 			return spec.log().all().post(authUrl).then().log().all().extract().response();
@@ -277,8 +305,11 @@ public final class RestClientAuth {
 
 	private static JSONObject buildNestedRequestForRole(String role, String contextKey) {
 		try {
-			if (AuthTokenStore.ROLE_ADMIN.equals(role) || AuthTokenStore.ROLE_SYSTEM.equals(role)) {
-				return buildAdminNestedRequest(contextKey);
+			if (AuthTokenStore.ROLE_ADMIN.equals(role)) {
+				return buildInternalNestedRequest(contextKey, false);
+			}
+			if (AuthTokenStore.ROLE_SYSTEM.equals(role)) {
+				return buildInternalNestedRequest(contextKey, true);
 			}
 			if (AuthTokenStore.ROLE_RESIDENT.equals(role)) {
 				return buildClientSecretRequest(contextKey, "mosip_resident_app_id", "mosip_resident_client_id",

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/variables/VariableManager.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/variables/VariableManager.java
@@ -2,11 +2,8 @@ package io.mosip.testrig.dslrig.dataprovider.variables;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Properties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -25,9 +22,6 @@ public final class VariableManager {
 	private static final Logger logger = LoggerFactory.getLogger(VariableManager.class);
 	public static String CONFIG_PATH = DataProviderConstants.RESOURCE + "config/";
 	public static String NS_DEFAULT = "mosipdefault";
-
-	private static String VAR_SUBSTITUE_PATTERN = "\\{\\{%s\\}\\}";
-	private static String VAR_FIND_PATTERN = "\\{\\{[_a-zA-Z]+[0-9]*[\\.]?[_a-zA-Z]+[0-9]*\\}\\}";
 
 	static Hashtable<String, Cache<String, Object>> varNameSpaces;
 	static MutableConfiguration<String, Object> cacheConfig;
@@ -109,24 +103,15 @@ public final class VariableManager {
 }
 
 	public static String[] findVariables(String text) {
+		return VariableSubstitution.findVariables(text);
+	}
 
-		HashSet<String> set = new HashSet<String>();
-
-		Pattern pattern = Pattern.compile(VAR_FIND_PATTERN);
-		Matcher matcher = pattern.matcher(text);
-		while (matcher.find()) {
-			String extract = text.substring(matcher.start(), matcher.end());
-
-			if (extract != null && extract.startsWith("{{"))
-				extract = extract.substring(2);
-			if (extract != null && extract.endsWith("}}"))
-				extract = extract.substring(0, extract.length() - 2);
-
-			set.add(extract.trim());
-
-		}
-		String[] a = new String[set.size()];
-		return set.toArray(a);
+	/**
+	 * Replaces all {@code {{variable}}} placeholders using values from {@code contextKey} and
+	 * {@link #NS_DEFAULT} (including {@code {{default.name}}} aliases).
+	 */
+	public static String substituteAll(String text, String contextKey) {
+		return VariableSubstitution.substituteAll(text, contextKey);
 	}
 
 	public static Object getVariableValue(String contextKey, String varName) {
@@ -204,10 +189,9 @@ public final class VariableManager {
 		logger.info(s.toString());
 	}
 
+	@Deprecated
 	static String substituteVaraiable(String text, String varName, String varValue) {
-		String formatVarName = String.format(VAR_SUBSTITUE_PATTERN, varName);
-		return text.replaceAll(formatVarName, varValue);
-
+		return VariableSubstitution.substituteOne(text, varName, varValue);
 	}
 
 	public static void main(String[] args) {

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/variables/VariableSubstitution.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/variables/VariableSubstitution.java
@@ -1,0 +1,98 @@
+package io.mosip.testrig.dslrig.dataprovider.variables;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves {@code {{variable}}} and {@code {{namespace.name}}} placeholders against {@link VariableManager}.
+ */
+public final class VariableSubstitution {
+
+	private static final Pattern VAR_FIND_PATTERN = Pattern
+			.compile("\\{\\{([_a-zA-Z][-_a-zA-Z0-9]*(?:\\.[_a-zA-Z][-_a-zA-Z0-9]*)*)\\}\\}");
+
+	private VariableSubstitution() {
+	}
+
+	public static String[] findVariables(String text) {
+		if (text == null || text.isEmpty()) {
+			return new String[0];
+		}
+		Set<String> names = new LinkedHashSet<>();
+		Matcher matcher = VAR_FIND_PATTERN.matcher(text);
+		while (matcher.find()) {
+			names.add(matcher.group(1).trim());
+		}
+		return names.toArray(new String[0]);
+	}
+
+	/**
+	 * Replaces every {@code {{...}}} reference in {@code text} for which a value can be resolved.
+	 * Unresolved placeholders are left unchanged.
+	 */
+	public static String substituteAll(String text, String contextKey) {
+		if (text == null || text.isEmpty()) {
+			return text;
+		}
+		String result = text;
+		for (String varRef : findVariables(text)) {
+			String value = resolve(contextKey, varRef);
+			if (value != null) {
+				result = substituteOne(result, varRef, value);
+			}
+		}
+		return result;
+	}
+
+	public static String substituteOne(String text, String varName, String varValue) {
+		if (text == null || varName == null || varValue == null) {
+			return text;
+		}
+		String placeholder = "{{" + varName + "}}";
+		return text.replace(placeholder, varValue);
+	}
+
+	static String resolve(String contextKey, String varRef) {
+		if (varRef == null || varRef.isBlank()) {
+			return null;
+		}
+		Object direct = lookup(contextKey, varRef);
+		if (direct != null) {
+			return direct.toString();
+		}
+		int dot = varRef.indexOf('.');
+		if (dot > 0) {
+			String namespace = varRef.substring(0, dot);
+			String name = varRef.substring(dot + 1);
+			Object namespaced = lookup(resolveNamespace(namespace), name);
+			if (namespaced != null) {
+				return namespaced.toString();
+			}
+		}
+		Object fallback = lookup(VariableManager.NS_DEFAULT, varRef);
+		return fallback != null ? fallback.toString() : null;
+	}
+
+	private static String resolveNamespace(String namespace) {
+		if (namespace == null) {
+			return VariableManager.NS_DEFAULT;
+		}
+		if ("default".equalsIgnoreCase(namespace) || "mosipdefault".equalsIgnoreCase(namespace)) {
+			return VariableManager.NS_DEFAULT;
+		}
+		return namespace;
+	}
+
+	private static Object lookup(String namespace, String name) {
+		if (namespace == null || name == null || name.isBlank()) {
+			return null;
+		}
+		try {
+			return VariableManager.getVariableValue(namespace, name);
+		} catch (Exception ignored) {
+			return null;
+		}
+	}
+}

--- a/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/variables/VariableSubstitution.java
+++ b/mosipTestDataProvider/src/io/mosip/testrig/dslrig/dataprovider/variables/VariableSubstitution.java
@@ -37,7 +37,9 @@ public final class VariableSubstitution {
 			return text;
 		}
 		String result = text;
-		for (String varRef : findVariables(text)) {
+		Matcher matcher = VAR_FIND_PATTERN.matcher(text);
+		while (matcher.find()) {
+			String varRef = matcher.group(1).trim();
 			String value = resolve(contextKey, varRef);
 			if (value != null) {
 				result = substituteOne(result, varRef, value);


### PR DESCRIPTION
Parallel DSL / packet-creator runs were unsafe and slow because of:

JVM-wide auth tokens — tokens keyed only by role/URL, cleared globally on persona creation, causing cross-worker auth bleed and redundant logins.

Fragmented masterdata caching — multiple cache paths; unclear warm/clear lifecycle for parallel workers.

Heavy persona hot path — finger/iris/face/document capture ran during every persona generate(), slowing scenario startup.

Maintainability debt — large god-classes (RestClient, VariableManager, PacketTemplateProvider), duplicate Cucumber JSON usage, unused Maven dependencies, IDE/source-root misconfiguration for tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred biometric assembly for personas to speed test-data generation.
  * Unified run-scoped masterdata cache for faster masterdata lookups.

* **Improvements**
  * Centralized token management and more robust auth handling for reliable requests.
  * Enhanced persona/demographics builder for cleaner, configurable identity generation.
  * Exposed select data/photo generation helpers for broader reuse.

* **Documentation**
  * Clarified run-cache warm/clear guidance and added cache-version reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/mosip-automation-tests/pull/979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->