### PR TITLE
MOSIP-45372-Bump central-publishing-maven-plugin to 0.8.0 and kernel.core.version to 1.3.0

### DIFF
--- a/mosip-acceptance-tests/ivv-orchestrator/pom.xml
+++ b/mosip-acceptance-tests/ivv-orchestrator/pom.xml
@@ -29,7 +29,7 @@
 	<properties>
 		<suiteXmlFile>testng.xml</suiteXmlFile>
 		<maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.8.0</central.publishing.maven.plugin.version>
 	</properties>
 
 	<distributionManagement>

--- a/mosip-acceptance-tests/pom.xml
+++ b/mosip-acceptance-tests/pom.xml
@@ -38,7 +38,7 @@
 	</modules>
 
 	<properties>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.8.0</central.publishing.maven.plugin.version>
 	</properties>
 
 	<dependencies>

--- a/mosip-packet-creator/pom.xml
+++ b/mosip-packet-creator/pom.xml
@@ -43,8 +43,8 @@
 		<java.version>21</java.version>
 		<maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
 		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<kernel.core.version>1.3.0-SNAPSHOT</kernel.core.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<kernel.core.version>1.3.0</kernel.core.version>
+		<central.publishing.maven.plugin.version>0.8.0</central.publishing.maven.plugin.version>
 	</properties>
 
 	<dependencies>

--- a/mosipTestDataProvider/pom.xml
+++ b/mosipTestDataProvider/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.5.0-SNAPSHOT</version>
 	<properties>
 		<maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.8.0</central.publishing.maven.plugin.version>
 	</properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
                 <sonar.exclusions>${sonar.coverage.exclusions}</sonar.exclusions>
                 <sonar.host.url>https://sonarcloud.io</sonar.host.url>
                 <sonar.organization>mosip</sonar.organization>
-                <central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+                <central.publishing.maven.plugin.version>0.8.0</central.publishing.maven.plugin.version>
             </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
## Summary
- Bump `central.publishing.maven.plugin.version` from 0.7.0 to 0.8.0 in `pom.xml`
- Bump `kernel.core.version` from 1.3.0-SNAPSHOT to 1.3.0 in `mosip-packet-creator/pom.xml`

## Test plan
- [ ] Verify project builds cleanly with updated plugin/dependency versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)